### PR TITLE
use JSON against modern (19+) OpenNMS instead of XML

### DIFF
--- a/src/api/ServerMetadata.ts
+++ b/src/api/ServerMetadata.ts
@@ -51,6 +51,11 @@ export class ServerMetadata {
     return this.version.ge('15.0.2');
   }
 
+  /** Is it safe to use JSON for most operations? */
+  public useJson() {
+    return this.version.ge('19.0.0');
+  }
+
   /** What version of the ReST API does this server support? */
   public apiVersion() {
     if (this.type && this.type === ServerTypes.MERIDIAN) {

--- a/src/dao/AbstractDAO.ts
+++ b/src/dao/AbstractDAO.ts
@@ -156,8 +156,13 @@ export abstract class AbstractDAO<K, T> {
    */
   protected getOptions(filter?: Filter): OnmsHTTPOptions {
     const ret = new OnmsHTTPOptions();
-    // always use application/xml for now in DAO calls
-    ret.headers.accept = 'application/xml';
+    if (this.useJson()) {
+      ret.headers.accept = 'application/json';
+    } else {
+      // always use application/xml in DAO calls when we're not sure how
+      // usable JSON output will be.
+      ret.headers.accept = 'application/xml';
+    }
     if (filter) {
       ret.parameters = this.filterProcessor.getParameters(filter);
     }
@@ -180,6 +185,13 @@ export abstract class AbstractDAO<K, T> {
   protected toNumber(from: any): number|undefined {
     const ret = parseInt(from, 10);
     return isNaN(ret) ? undefined : ret;
+  }
+
+  protected useJson(): boolean {
+    if (this.http === undefined || this.http.server === undefined || this.http.server.metadata === undefined) {
+      throw new OnmsError('Server meta-data must be populated prior to making DAO calls.');
+    }
+    return this.http.server.metadata.useJson();
   }
 
   /**


### PR DESCRIPTION
Just wanted someone to review this to make sure it's reasonable, but this PR makes opennms.js use JSON responses by default in DAOs if we're connecting to Horizon 19 or higher.