### PR TITLE
JS-15: support dates in v1 and v2 queries

### DIFF
--- a/src/dao/V1FilterProcessor.ts
+++ b/src/dao/V1FilterProcessor.ts
@@ -1,5 +1,6 @@
 import {IHash} from '../internal/IHash';
 import {OnmsEnum} from '../internal/OnmsEnum';
+import {Util} from '../internal/Util';
 
 import {IFilterProcessor} from '../api/IFilterProcessor';
 
@@ -59,11 +60,13 @@ export class V1FilterProcessor implements IFilterProcessor {
             throw new OnmsError('V1 only supports one restriction comparator type!');
           }
           ret.comparator = comp;
-          let value = '' + restriction.value;
           if (restriction.value instanceof OnmsEnum) {
-            value = (restriction.value as OnmsEnum<any>).label;
+            ret[restriction.attribute] = (restriction.value as OnmsEnum<any>).label;
+          } else if (Util.isDateObject(restriction.value)) {
+            ret[restriction.attribute] = Util.toDateString(restriction.value);
+          } else {
+            ret[restriction.attribute] = '' + restriction.value;
           }
-          ret[restriction.attribute] = value;
         }
       }
     }

--- a/src/dao/V2FilterProcessor.ts
+++ b/src/dao/V2FilterProcessor.ts
@@ -1,4 +1,5 @@
 import {IHash} from '../internal/IHash';
+import {Util} from '../internal/Util';
 
 import {IFilterProcessor} from '../api/IFilterProcessor';
 
@@ -60,7 +61,11 @@ export class V2FilterProcessor implements IFilterProcessor {
       case Comparators.NOTNULL:
         return restriction.value === undefined ? V2FilterProcessor.NULL_VALUE : restriction.value;
       default:
-        return restriction.value;
+        if (Util.isDateObject(restriction.value)) {
+          return Util.toDateString(restriction.value);
+        } else {
+          return restriction.value;
+        }
     }
   }
 

--- a/src/internal/Util.ts
+++ b/src/internal/Util.ts
@@ -1,4 +1,14 @@
+import {OnmsError} from '../api/OnmsError';
+
 import {Address4, Address6} from 'ip-address';
+import {Moment} from 'moment';
+
+/** @hidden */
+// tslint:disable-next-line
+const moment = require('moment');
+
+/** @hidden */
+const dateFormat = 'YYYY-MM-DDTHH:mm:ss.SSSZZ';
 
 /**
  * A utility class for random stuff.
@@ -18,5 +28,45 @@ export class Util {
       }
     }
     return undefined;
+  }
+
+  /**
+   * Whether or not the passed object is already a date. (Either a [[Moment]] object, or
+   * a JavaScript [[Date]] object.)
+   */
+  public static isDateObject(date: any) {
+    return moment.isMoment(date) || date instanceof Date;
+  }
+
+  /**
+   * Create a [[Moment]] from any form of date (JavaScript [[Date]], [[Moment]], or epoch).
+   * [[Moment]] dates in OpenNMS.js will always be converted internally to UTC to avoid time
+   * zone issues.
+   */
+  public static toMoment(date: Date|Moment|string|number): Moment {
+    if (date === undefined || date === null) {
+      return undefined;
+    } else if (moment.isMoment(date)) {
+      return (date as Moment).utc();
+    } else if (typeof(date) === 'number' || date instanceof Date
+      || typeof(date) === 'string' || date instanceof String) {
+      return moment(date).utc();
+    } else {
+      throw new OnmsError('Unable to parse type "' + typeof(date) + '" as a date.');
+    }
+  }
+
+  /**
+   * Create a date string from any form of date (JavaScript [[Date]], [[Moment]], or epoch).
+   * Dates in OpenNMS.js will always be converted internally to UTC before stringifying to
+   * avoid time zone issues.
+   */
+  public static toDateString(date: Date|Moment|number) {
+    const ret = Util.toMoment(date);
+    if (ret) {
+      return ret.utc().format(dateFormat);
+    } else {
+      return undefined;
+    }
   }
 }

--- a/test/dao/V1FilterProcessor.spec.ts
+++ b/test/dao/V1FilterProcessor.spec.ts
@@ -77,4 +77,12 @@ describe('V1FilterProcessor', () => {
       proc.getParameters(filter);
     }).toThrow(OnmsError);
   });
+  it('alarm filter: lastEventTime=1976-04-14T00:00:00.000+0000', () => {
+    const filter = new Filter();
+    filter.withOrRestriction(new Restriction('lastEventTime', Comparators.EQ, new Date(198288000000)));
+    const proc = new V1FilterProcessor();
+    expect(proc.getParameters(filter)).toMatchObject({
+      lastEventTime: '1976-04-14T00:00:00.000+0000'
+    });
+  });
 });

--- a/test/dao/V2FilterProcessor.spec.ts
+++ b/test/dao/V2FilterProcessor.spec.ts
@@ -89,4 +89,9 @@ describe('V2FilterProcessor', () => {
         );
     expect(toSearch(filter)).toEqual('id!=0;(severity==5,uei==*somethingWentWrong)');
   });
+  it('alarm filter: lastEventTime=1976-04-14T00:00:00.000+0000', () => {
+    const filter = new Filter();
+    filter.withAndRestriction(new Restriction('lastEventTime', Comparators.EQ, new Date(198288000000)));
+    expect(toSearch(filter)).toEqual('lastEventTime==1976-04-14T00:00:00.000+0000');
+  });
 });

--- a/test/internal/Util.spec.ts
+++ b/test/internal/Util.spec.ts
@@ -1,7 +1,19 @@
-declare const describe, beforeEach, it, expect;
+declare const describe, beforeEach, it, expect, require;
 
 import {Util} from '../../src/internal/Util';
+
 import {Address4, Address6} from 'ip-address';
+import {Moment} from 'moment';
+
+/** @hidden */
+// tslint:disable-next-line
+const moment = require('moment');
+
+/** @hidden */
+const ARBITRARY_STRING = '2017-08-08T12:29:56.000+0000';
+
+/** @hidden */
+const ARBITRARY_EPOCH = 1502195396000;
 
 describe('Util.toIPAddress()', () => {
   it('undefined', () => {
@@ -21,5 +33,71 @@ describe('Util.toIPAddress()', () => {
     const addr = Util.toIPAddress('2003:dead:beef::1');
     expect(addr).toBeInstanceOf(Address6);
     expect(addr.isValid()).toEqual(true);
+  });
+});
+
+describe('Util.isDateObject()', () => {
+  it('undefined', () => {
+    expect(Util.isDateObject(undefined)).toEqual(false);
+  });
+  it('null', () => {
+    expect(Util.isDateObject(null)).toEqual(false);
+  });
+  it('moment(0)', () => {
+    expect(Util.isDateObject(moment(0))).toEqual(true);
+  });
+  it('0', () => {
+    expect(Util.isDateObject(0)).toEqual(false);
+  });
+  it('new Date()', () => {
+    expect(Util.isDateObject(new Date(ARBITRARY_EPOCH))).toEqual(true);
+  });
+  it(ARBITRARY_STRING, () => {
+    expect(Util.isDateObject(ARBITRARY_STRING)).toEqual(false);
+  });
+  it('2017-08-08T12:29:56Z', () => {
+    expect(Util.isDateObject('2017-08-08T12:29:56Z')).toEqual(false);
+  });
+});
+
+describe('Util.toMoment()', () => {
+  it('undefined', () => {
+    expect(Util.toMoment(undefined)).toBeUndefined();
+  });
+  it('null', () => {
+    expect(Util.toMoment(null)).toBeUndefined();
+  });
+  it('moment(0)', () => {
+    expect(Util.toMoment(moment(0)).valueOf()).toEqual(0);
+  });
+  it('0', () => {
+    expect(Util.toMoment(0).valueOf()).toEqual(0);
+  });
+  it('new Date()', () => {
+    expect(Util.toMoment(new Date(ARBITRARY_EPOCH)).valueOf()).toEqual(ARBITRARY_EPOCH);
+  });
+  it(ARBITRARY_STRING, () => {
+    expect(Util.toMoment(ARBITRARY_STRING).valueOf()).toEqual(ARBITRARY_EPOCH);
+  });
+  it('2017-08-08T12:29:56Z', () => {
+    expect(Util.toMoment('2017-08-08T12:29:56Z').valueOf()).toEqual(ARBITRARY_EPOCH);
+  });
+});
+
+describe('Util.toDateString()', () => {
+  it('undefined', () => {
+    expect(Util.toDateString(undefined)).toBeUndefined();
+  });
+  it('null', () => {
+    expect(Util.toDateString(null)).toBeUndefined();
+  });
+  it('moment(0)', () => {
+    expect(Util.toDateString(moment(0))).toEqual('1970-01-01T00:00:00.000+0000');
+  });
+  it('0', () => {
+    expect(Util.toDateString(0)).toEqual('1970-01-01T00:00:00.000+0000');
+  });
+  it('new Date()', () => {
+    expect(Util.toDateString(new Date(ARBITRARY_EPOCH))).toEqual(ARBITRARY_STRING);
   });
 });


### PR DESCRIPTION
This PR adds support for handling dates cleanly in ReST queries.