### PR TITLE
JS-19: allow passing user to unack as well

### DIFF
--- a/src/dao/AlarmDAO.ts
+++ b/src/dao/AlarmDAO.ts
@@ -122,10 +122,13 @@ export class AlarmDAO extends AbstractDAO<number, OnmsAlarm> {
    * @version ReST v1+
    * @param {number|OnmsAlarm} alarm - The [[OnmsAlarm]] or alarm ID.
    */
-  public async unacknowledge(alarm: number|OnmsAlarm): Promise<void> {
+  public async unacknowledge(alarm: number|OnmsAlarm, user?: string): Promise<void> {
     const alarmId = (typeof(alarm) === 'number' ? alarm : alarm.id);
     const parameters = {} as IHash<string>;
     parameters.ack = 'false';
+    if (user !== undefined) {
+      parameters.ackUser = user;
+    }
     return this.put(this.pathToAlarmsEndpoint() + '/' + alarmId, parameters);
   }
 

--- a/test/dao/AlarmDAO.spec.ts
+++ b/test/dao/AlarmDAO.spec.ts
@@ -69,6 +69,12 @@ describe('AlarmDAO with v1 API', () => {
       return dao[method](alarm);
     });
   }
+  it('AlarmDAO.acknowledge(id=404725, user=ranger)', () => {
+    return dao.acknowledge(404725, 'ranger');
+  });
+  it('AlarmDAO.unacknowledge(id=404725, user=ranger)', () => {
+    return dao.unacknowledge(404725, 'ranger');
+  });
 
   it('AlarmDAO.setTTicketId(alarmId=404725, ticketId=abcde)', () => {
     return dao.setTTicketId(404725, 'abcde');
@@ -199,6 +205,12 @@ describe('AlarmDAO with v2 API', () => {
       return dao[method](alarm);
     });
   }
+  it('AlarmDAO.acknowledge(id=404725, user=ranger)', () => {
+    return dao.acknowledge(404725, 'ranger');
+  });
+  it('AlarmDAO.unacknowledge(id=404725, user=ranger)', () => {
+    return dao.unacknowledge(404725, 'ranger');
+  });
 
   it('AlarmDAO.setTTicketId(alarmId=404725, ticketId=abcde)', () => {
     return dao.setTTicketId(404725, 'abcde');

--- a/test/rest/MockHTTP19.ts
+++ b/test/rest/MockHTTP19.ts
@@ -87,6 +87,11 @@ export class MockHTTP19 extends AbstractHTTP {
         result.type = 'text/plain';
         return Promise.resolve(result);
       }
+      case 'rest/alarms/404725?ack=false&ackUser=ranger': {
+        const result = OnmsResult.ok('');
+        result.type = 'text/plain';
+        return Promise.resolve(result);
+      }
       case 'rest/alarms/404725?ack=false': {
         const result = OnmsResult.ok('');
         result.type = 'text/plain';

--- a/test/rest/MockHTTP21.ts
+++ b/test/rest/MockHTTP21.ts
@@ -99,6 +99,11 @@ export class MockHTTP21 extends AbstractHTTP {
         result.type = 'text/plain';
         return Promise.resolve(result);
       }
+      case 'api/v2/alarms/404725?ack=false&ackUser=ranger': {
+        const result = OnmsResult.ok('');
+        result.type = 'text/plain';
+        return Promise.resolve(result);
+      }
       case 'api/v2/alarms/404725?ack=false': {
         const result = OnmsResult.ok('');
         result.type = 'text/plain';


### PR DESCRIPTION
It's possible to pass `ackUser` to `unack` as well, to denote who un-acknowledged the alarm.