### PR TITLE
JS-13: improve error handling when ReST calls fail

### DIFF
--- a/src/api/OnmsError.ts
+++ b/src/api/OnmsError.ts
@@ -1,5 +1,5 @@
 /**
- * Represents an OpenNMS.js error.  This will eventually have custom stuff to do... stuff.
+ * Represents an OpenNMS.js error.
  * @module OnmsError
  */
 export class OnmsError extends Error {
@@ -9,8 +9,14 @@ export class OnmsError extends Error {
    */
   private statusCode: number;
 
+  /**
+   * The data (payload) associated with a response.
+   */
   private data: any;
 
+  /**
+   * The options provided as part of the request that resulted in this erro.
+   */
   private options: any;
 
   /** The error code associated with this error. */
@@ -35,6 +41,8 @@ export class OnmsError extends Error {
       } else {
           this.stack = (new Error(message)).stack;
       }
+      // workaround, see http://bit.ly/2vllGdD
+      Object.setPrototypeOf(this, OnmsError.prototype);
   }
 
   /**

--- a/src/api/OnmsError.ts
+++ b/src/api/OnmsError.ts
@@ -2,38 +2,20 @@
  * Represents an OpenNMS.js error.  This will eventually have custom stuff to do... stuff.
  * @module OnmsError
  */
-export class OnmsError {
+export class OnmsError extends Error {
   /**
    * The response status code, if any.
    * @hidden
    */
   private statusCode: number;
 
-  /**
-   * We need a real JS Error because it can't be subclassed.
-   * @hidden
-   */
-  private errorObj: Error;
+  private data: any;
 
-  /**
-   * The stack trace so this object is loggable.
-   * @hidden
-   */
-  private stack;
+  private options: any;
 
   /** The error code associated with this error. */
   public get code() {
     return this.statusCode;
-  }
-
-  /** The JS Error class associated with this error. */
-  public get error() {
-    return this.errorObj;
-  }
-
-  /** The error message. */
-  public get message() {
-    return this.errorObj.message;
   }
 
   /**
@@ -42,10 +24,17 @@ export class OnmsError {
    * @param message - The error message.
    * @param code - An optional error code to associate with the error.
    */
-  constructor(public mess: string, code?: number) {
-    this.errorObj = new Error(mess);
-    this.statusCode = code;
-    this.stack = this.errorObj.stack;
+  constructor(message: string, code?: number, options?: any, data?: any) {
+      super(message);
+      this.name = this.constructor.name;
+      this.statusCode = code;
+      this.data = data;
+      this.options = options;
+      if (typeof Error.captureStackTrace === 'function') {
+          Error.captureStackTrace(this, this.constructor);
+      } else {
+          this.stack = (new Error(message)).stack;
+      }
   }
 
   /**

--- a/src/api/OnmsResult.ts
+++ b/src/api/OnmsResult.ts
@@ -1,15 +1,8 @@
-import {OnmsError} from './OnmsError';
-
 /**
  * An [[IOnmsHTTP]] query result.
  * @module OnmsResult
  */
 export class OnmsResult<T> {
-  /** Create a new error result. */
-  public static error(message: string, code?: number) {
-    return new OnmsResult(undefined, message, code);
-  }
-
   /** Create a new success result. */
   public static ok(response: any, message?: string, code?: number, type?: string) {
     return new OnmsResult(response, message || 'OK', code || 200, type);

--- a/src/rest/AbstractHTTP.ts
+++ b/src/rest/AbstractHTTP.ts
@@ -125,7 +125,7 @@ export abstract class AbstractHTTP implements IOnmsHTTP {
    * A callback to handle any request errors.
    * @hidden
    */
-  protected handleError(err: any): never {
+  protected handleError(err: any, options?: any): never {
     const message = AbstractHTTP.extractMessage(err);
     const status = AbstractHTTP.extractStatus(err);
     if (status) {

--- a/src/rest/AxiosHTTP.ts
+++ b/src/rest/AxiosHTTP.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import {AxiosStatic, AxiosInstance, AxiosRequestConfig} from 'axios';
+import {AxiosStatic, AxiosInstance, AxiosResponse, AxiosRequestConfig} from 'axios';
 import * as qs from 'qs';
 import * as clonedeep from 'lodash.clonedeep';
 
@@ -70,8 +70,10 @@ export class AxiosHTTP extends AbstractHTTP {
       if (response.headers && response.headers['content-type']) {
         type = response.headers['content-type'];
       }
-      return OnmsResult.ok(response.data, undefined, response.status, type);
-    }).catch(this.handleError);
+      return OnmsResult.ok(this.getData(response), undefined, response.status, type);
+    }).catch((err) => {
+      throw this.handleError(err, opts);
+    });
   }
 
   /**
@@ -94,8 +96,10 @@ export class AxiosHTTP extends AbstractHTTP {
       if (response.headers && response.headers['content-type']) {
         type = response.headers['content-type'];
       }
-      return OnmsResult.ok(response.data, undefined, response.status, type);
-    }).catch(this.handleError);
+      return OnmsResult.ok(this.getData(response), undefined, response.status, type);
+    }).catch((err) => {
+      throw this.handleError(err, opts);
+    });
   }
 
   /**
@@ -117,8 +121,10 @@ export class AxiosHTTP extends AbstractHTTP {
       if (response.headers && response.headers['content-type']) {
         type = response.headers['content-type'];
       }
-      return OnmsResult.ok(response.data, undefined, response.status, type);
-    }).catch(this.handleError);
+      return OnmsResult.ok(this.getData(response), undefined, response.status, type);
+    }).catch((err) => {
+      throw this.handleError(err, opts);
+    });
   }
 
   /**
@@ -140,8 +146,10 @@ export class AxiosHTTP extends AbstractHTTP {
         if (response.headers && response.headers['content-type']) {
             type = response.headers['content-type'];
         }
-        return OnmsResult.ok(response.data, undefined, response.status, type);
-    }).catch(this.handleError);
+        return OnmsResult.ok(this.getData(response), undefined, response.status, type);
+    }).catch((err) => {
+      throw this.handleError(err, opts);
+    });
   }
 
   /**
@@ -160,7 +168,9 @@ export class AxiosHTTP extends AbstractHTTP {
   private getConfig(options?: OnmsHTTPOptions): AxiosRequestConfig {
     const allOptions = this.getOptions(options);
 
-    const ret = {} as AxiosRequestConfig;
+    const ret = {
+      transformResponse: [], // we do this so we can post-process only on success
+    } as AxiosRequestConfig;
 
     if (allOptions.auth && allOptions.auth.username && allOptions.auth.password) {
       ret.auth = {
@@ -187,15 +197,13 @@ export class AxiosHTTP extends AbstractHTTP {
     }
 
     const type = ret.headers.accept;
+    ret.transformResponse = [];
     if (type === 'application/json') {
       ret.responseType = 'json';
-      ret.transformResponse = this.transformJSON;
     } else if (type === 'text/plain') {
       ret.responseType = 'text';
-      delete ret.transformResponse;
     } else if (type === 'application/xml') {
       ret.responseType = 'text';
-      ret.transformResponse = this.transformXML;
     } else {
       throw new OnmsError('Unhandled "Accept" header: ' + type);
     }

--- a/src/rest/GrafanaError.ts
+++ b/src/rest/GrafanaError.ts
@@ -1,12 +1,26 @@
 import {OnmsError} from '../api/OnmsError';
 
+/**
+ * A Grafana error object.
+ * @module GrafanaError
+ */
 export class GrafanaError extends OnmsError {
+  /**
+   * The request options (configuration).
+   * @hidden
+   */
+  private config: any;
 
-    private config: any;
-
-    constructor(message: string, code?: number, options?: any, data?: any) {
-        super(message, code, options, data);
-        this.config = options;
-    }
+  /**
+   * Construct a new Grafana error.
+   * @param message The status message associated with the result.
+   * @param code The response code of the response.
+   * @param options The request options (configuration).
+   * @param data The payload of the response.
+   */
+  constructor(message: string, code?: number, options?: any, data?: any) {
+    super(message, code, options, data);
+    this.config = options;
+  }
 
 }

--- a/src/rest/GrafanaError.ts
+++ b/src/rest/GrafanaError.ts
@@ -1,0 +1,12 @@
+import {OnmsError} from '../api/OnmsError';
+
+export class GrafanaError extends OnmsError {
+
+    private config: any;
+
+    constructor(message: string, code?: number, options?: any, data?: any) {
+        super(message, code, options, data);
+        this.config = options;
+    }
+
+}

--- a/src/rest/GrafanaHTTP.ts
+++ b/src/rest/GrafanaHTTP.ts
@@ -140,40 +140,26 @@ export class GrafanaHTTP extends AbstractHTTP {
    */
   private getConfig(options?: OnmsHTTPOptions): any {
     const allOptions = this.getOptions(options);
-    const ret = {
-      transformResponse: [], // we do this so we can post-process only on success
-    } as any;
+    const ret = clonedeep(allOptions);
+    ret.transformResponse = []; // we do this so we can post-process only on success
 
-    if (allOptions.headers) {
+    if (!allOptions.headers) {
       ret.headers = clonedeep(allOptions.headers);
     } else {
       ret.headers = {};
     }
 
+    // Enforce Accept-Header
     if (!ret.headers.accept) {
       ret.headers.accept = 'application/json';
     }
-    if (!ret.headers['content-type']) {
+    // Enforce Content-Type-Header when data is being sent
+    if (ret.data && !ret.headers['content-type']) {
       ret.headers['content-type'] = 'application/json;charset=utf-8';
     }
-
-    const type = ret.headers.accept;
-    if (type === 'application/json') {
-      ret.responseType = 'json';
-    } else if (type === 'text/plain') {
-      ret.responseType = 'text';
-    } else if (type === 'application/xml') {
-      ret.responseType = 'text';
-    } else {
-      throw new OnmsError('Unhandled "Accept" header: ' + type);
-    }
-
-    if (allOptions.parameters && Object.keys(allOptions.parameters).length > 0) {
-      ret.params = clonedeep(allOptions.parameters);
-    }
-
-    if (allOptions.data) {
-      ret.data = clonedeep(allOptions.data);
+    if (ret.parameters && Object.keys(ret.parameters).length > 0) {
+      ret.params = ret.parameters;
+      delete ret.parameters;
     }
     return ret;
   }

--- a/src/rest/GrafanaHTTP.ts
+++ b/src/rest/GrafanaHTTP.ts
@@ -126,12 +126,12 @@ export class GrafanaHTTP extends AbstractHTTP {
      * @hidden
      */
     protected handleError(err: any, options?: any): never {
-        let message = AbstractHTTP.extractMessage(err);
-        const status = AbstractHTTP.extractStatus(err);
-        if (!status) {
-            message = 'An unknown error has occurred: ' + message;
-        }
-        throw new GrafanaError(message, status, options, err);
+      let message = AbstractHTTP.extractMessage(err);
+      if (err && err.data && err.data.response && (typeof (err.data.response) === 'string')) {
+          message = err.data.response;
+      }
+      const status = AbstractHTTP.extractStatus(err);
+      throw new GrafanaError(message, status, options, err);
     }
 
   /**

--- a/src/rest/GrafanaHTTP.ts
+++ b/src/rest/GrafanaHTTP.ts
@@ -8,7 +8,7 @@ import {log, catRest} from '../api/Log';
 import {Category} from 'typescript-logging';
 
 import * as clonedeep from 'lodash.clonedeep';
-import {Util} from '../internal/Util';
+import {GrafanaError} from './GrafanaError';
 
 /** @hidden */
 const catGrafana = new Category('grafana', catRest);
@@ -52,7 +52,9 @@ export class GrafanaHTTP extends AbstractHTTP {
         type = response.headers['content-type'];
       }
       return OnmsResult.ok(response.data, undefined, response.status, type);
-    }).catch(this.handleError);
+    }).catch((e) => {
+      this.handleError(e, query);
+    });
   }
 
   /** Make an HTTP PUT call using the Grafana `BackendSrv`. */
@@ -72,7 +74,9 @@ export class GrafanaHTTP extends AbstractHTTP {
         type = response.headers['content-type'];
       }
       return OnmsResult.ok(response.data, undefined, response.status, type);
-    }).catch(this.handleError);
+    }).catch((e) => {
+      this.handleError(e, query);
+    });
   }
 
   /** Make an HTTP POST call using the Grafana `BackendSrv`. */
@@ -91,7 +95,9 @@ export class GrafanaHTTP extends AbstractHTTP {
         type = response.headers['content-type'];
       }
       return OnmsResult.ok(response.data, undefined, response.status, type);
-    }).catch(this.handleError);
+    }).catch((e) => {
+      this.handleError(e, query);
+    });
   }
 
   /** Make an HTTP DELETE call using the Grafana `BackendSrv`. */
@@ -110,8 +116,23 @@ export class GrafanaHTTP extends AbstractHTTP {
         type = response.headers['content-type'];
       }
       return OnmsResult.ok(response.data, undefined, response.status, type);
-    }).catch(this.handleError);
+    }).catch((e) => {
+        this.handleError(e, query);
+    });
   }
+
+    /**
+     * A callback to handle any request errors.
+     * @hidden
+     */
+    protected handleError(err: any, options?: any): never {
+        let message = AbstractHTTP.extractMessage(err);
+        const status = AbstractHTTP.extractStatus(err);
+        if (!status) {
+            message = 'An unknown error has occurred: ' + message;
+        }
+        throw new GrafanaError(message, status, options, err);
+    }
 
   /**
    * Internal method to turn [[OnmsHTTPOptions]] into a Grafana `BackendSrv` request object.

--- a/src/rest/GrafanaHTTP.ts
+++ b/src/rest/GrafanaHTTP.ts
@@ -51,7 +51,7 @@ export class GrafanaHTTP extends AbstractHTTP {
       if (response.headers && response.headers['content-type']) {
         type = response.headers['content-type'];
       }
-      return OnmsResult.ok(response.data, undefined, response.status, type);
+      return OnmsResult.ok(this.getData(response), undefined, response.status, type);
     }).catch((e) => {
       this.handleError(e, query);
     });
@@ -73,7 +73,7 @@ export class GrafanaHTTP extends AbstractHTTP {
       if (response.headers && response.headers['content-type']) {
         type = response.headers['content-type'];
       }
-      return OnmsResult.ok(response.data, undefined, response.status, type);
+      return OnmsResult.ok(this.getData(response), undefined, response.status, type);
     }).catch((e) => {
       this.handleError(e, query);
     });
@@ -94,7 +94,7 @@ export class GrafanaHTTP extends AbstractHTTP {
       if (response.headers && response.headers['content-type']) {
         type = response.headers['content-type'];
       }
-      return OnmsResult.ok(response.data, undefined, response.status, type);
+      return OnmsResult.ok(this.getData(response), undefined, response.status, type);
     }).catch((e) => {
       this.handleError(e, query);
     });
@@ -115,7 +115,7 @@ export class GrafanaHTTP extends AbstractHTTP {
       if (response.headers && response.headers['content-type']) {
         type = response.headers['content-type'];
       }
-      return OnmsResult.ok(response.data, undefined, response.status, type);
+      return OnmsResult.ok(this.getData(response), undefined, response.status, type);
     }).catch((e) => {
         this.handleError(e, query);
     });
@@ -140,7 +140,9 @@ export class GrafanaHTTP extends AbstractHTTP {
    */
   private getConfig(options?: OnmsHTTPOptions): any {
     const allOptions = this.getOptions(options);
-    const ret = {} as any;
+    const ret = {
+      transformResponse: [], // we do this so we can post-process only on success
+    } as any;
 
     if (allOptions.headers) {
       ret.headers = clonedeep(allOptions.headers);
@@ -158,13 +160,10 @@ export class GrafanaHTTP extends AbstractHTTP {
     const type = ret.headers.accept;
     if (type === 'application/json') {
       ret.responseType = 'json';
-      ret.transformResponse = this.transformJSON;
     } else if (type === 'text/plain') {
       ret.responseType = 'text';
-      delete ret.transformResponse;
     } else if (type === 'application/xml') {
       ret.responseType = 'text';
-      ret.transformResponse = this.transformXML;
     } else {
       throw new OnmsError('Unhandled "Accept" header: ' + type);
     }

--- a/src/rest/JsonTransformer.ts
+++ b/src/rest/JsonTransformer.ts
@@ -1,3 +1,5 @@
+import {OnmsError} from '../api/OnmsError';
+
 /**
  * Helper to transform a json string to an json object.
  */
@@ -11,7 +13,11 @@ export class JsonTransformer {
             if (data.length < 1) {
                 return {};
             } else {
-                return JSON.parse(data);
+                try {
+                    return JSON.parse(data);
+                } catch (err) {
+                    throw new OnmsError(err.message, undefined, undefined, data);
+                }
             }
         } else {
             // assume it's already parsed

--- a/src/rest/XmlTransformer.ts
+++ b/src/rest/XmlTransformer.ts
@@ -7,6 +7,8 @@ if (global && !global.window) {
     }
 }
 
+import {OnmsError} from '../api/OnmsError';
+
 /** @hidden */
 // tslint:disable-next-line
 const X2JS = require('x2js');
@@ -28,7 +30,11 @@ export class XmlTransformer {
      */
     public transform(data: any) {
         if (typeof data === 'string') {
-            return xmlParser.xml2js(data);
+            try {
+                return xmlParser.xml2js(data);
+            } catch (err) {
+                throw new OnmsError(err.message, undefined, undefined, data);
+            }
         } else {
             // assume it's already parsed
             return data;

--- a/test/rest/MockHTTP19.ts
+++ b/test/rest/MockHTTP19.ts
@@ -67,7 +67,7 @@ export class MockHTTP19 extends AbstractHTTP {
       }
     }
 
-    return Promise.reject(OnmsResult.error('Not yet implemented: GET ' + urlObj.toString()));
+    throw new Error('Not yet implemented: GET ' + urlObj.toString());
   }
 
   public put(url: string, options?: OnmsHTTPOptions) {
@@ -119,7 +119,7 @@ export class MockHTTP19 extends AbstractHTTP {
       }
     }
 
-    return Promise.reject(OnmsResult.error('Not yet implemented: PUT ' + urlObj.toString()));
+    throw new Error('Not yet implemented: PUT ' + urlObj.toString());
   }
 
   public post(url: string, options?: OnmsHTTPOptions) {
@@ -138,11 +138,11 @@ export class MockHTTP19 extends AbstractHTTP {
       */
     }
 
-    return Promise.reject(OnmsResult.error('Not yet implemented: POST ' + urlObj.toString()));
+    throw new Error('Not yet implemented: POST ' + urlObj.toString());
   }
 
   public httpDelete(url: string, options?: OnmsHTTPOptions): Promise<OnmsResult<any>> {
     const urlObj = new URI(url);
-    return Promise.reject(OnmsResult.error('Not yet implemented: DELETE ' + urlObj.toString()));
+    throw new Error('Not yet implemented: DELETE ' + urlObj.toString());
   }
 }

--- a/test/rest/MockHTTP21.ts
+++ b/test/rest/MockHTTP21.ts
@@ -79,7 +79,8 @@ export class MockHTTP21 extends AbstractHTTP {
         return Promise.resolve(result);
       }
     }
-    return Promise.reject(OnmsResult.error('Not yet implemented: ' + urlObj.toString()));
+
+    throw new Error('Not yet implemented: GET ' + urlObj.toString());
   }
 
   public put(url: string, options?: OnmsHTTPOptions) {
@@ -143,7 +144,7 @@ export class MockHTTP21 extends AbstractHTTP {
       }
     }
 
-    return Promise.reject(OnmsResult.error('Not yet implemented: PUT ' + urlObj.toString()));
+    throw new Error('Not yet implemented: PUT ' + urlObj.toString());
   }
 
   public post(url: string, options?: OnmsHTTPOptions) {
@@ -173,7 +174,7 @@ export class MockHTTP21 extends AbstractHTTP {
       }
     }
 
-    return Promise.reject(OnmsResult.error('Not yet implemented: POST ' + urlObj.toString()));
+    throw new Error('Not yet implemented: POST ' + urlObj.toString());
   }
 
   public httpDelete(url: string, options?: OnmsHTTPOptions): Promise<OnmsResult<any>> {
@@ -197,6 +198,6 @@ export class MockHTTP21 extends AbstractHTTP {
       }
     }
 
-    return Promise.reject(OnmsResult.error('Not yet implemented: DELETE ' + urlObj.toString()));
+    throw new Error('Not yet implemented: DELETE ' + urlObj.toString());
   }
 }


### PR DESCRIPTION
* extend Error for the `OnmsError` object so it can be handled by normal JS catches properly
* `OnmsResult` is now only for non-error results
* parsing XML and JSON is now deferred until success, so that failed results are kept raw