### PR TITLE
HELM-110: add managedObjectInstance + managedObjectType

### DIFF
--- a/src/api/ServerMetadata.ts
+++ b/src/api/ServerMetadata.ts
@@ -36,7 +36,7 @@ export class ServerMetadata {
     return this.version.ge('14.0.0');
   }
 
-  /** Does this server flow data? */
+  /** Does this server support flow data? */
   public flows() {
     if (this.type && this.type === ServerTypes.MERIDIAN) {
       return this.version.ge('2019.0.0');

--- a/src/api/ServerMetadata.ts
+++ b/src/api/ServerMetadata.ts
@@ -36,6 +36,15 @@ export class ServerMetadata {
     return this.version.ge('14.0.0');
   }
 
+  /** Does this server flow data? */
+  public flows() {
+    if (this.type && this.type === ServerTypes.MERIDIAN) {
+      return this.version.ge('2019.0.0');
+    } else {
+      return this.version.ge('22.0.0');
+    }
+  }
+
   /** Does this server support graphs? (ie, the measurements API) */
   public graphs() {
     if (this.type && this.type === ServerTypes.MERIDIAN) {
@@ -64,6 +73,15 @@ export class ServerMetadata {
     }
   }
 
+  /** Does this server support situations? */
+  public situations() {
+    if (this.type && this.type === ServerTypes.MERIDIAN) {
+      return this.version.ge('2019.0.0');
+    } else {
+      return this.version.ge('23.0.0');
+    }
+  }
+
   /** Does this server support ticketer configuration metadata? */
   public ticketer() {
     if (this.type && this.type === ServerTypes.MERIDIAN) {
@@ -87,9 +105,11 @@ export class ServerMetadata {
     return {
       ackAlarms: this.ackAlarms(),
       apiVersion: this.apiVersion(),
+      flows: this.flows(),
       graphs: this.graphs(),
       outageSummaries: this.outageSummaries(),
       setNodeLocation: this.setNodeLocation(),
+      situations: this.situations(),
       ticketer: this.ticketer(),
       type: (this.type === ServerTypes.MERIDIAN ? 'Meridian' : 'Horizon'),
     };
@@ -101,9 +121,11 @@ export class ServerMetadata {
       + ',apiVersion=' + this.apiVersion()
       + ',type=' + this.type.toString()
       + ',ackAlarms=' + this.ackAlarms()
+      + ',flows=' + this.flows()
       + ',graphs=' + this.graphs()
       + ',outageSummaries=' + this.outageSummaries()
       + ',setNodeLocation=' + this.setNodeLocation()
+      + ',situations=' + this.situations()
       + ',ticketer=' + this.ticketer()
       + ']';
   }

--- a/src/dao/AlarmDAO.ts
+++ b/src/dao/AlarmDAO.ts
@@ -395,6 +395,9 @@ export class AlarmDAO extends AbstractDAO<number, OnmsAlarm> {
 
     alarm.relatedAlarms = data.relatedAlarms;
 
+    alarm.managedObjectType = data.managedObjectType;
+    alarm.managedObjectInstance = data.managedObjectInstance;
+
     alarm.sticky = this.toMemo(data.stickyMemo);
     alarm.journal = this.toMemo(data.reductionKeyMemo);
 

--- a/src/model/OnmsAlarm.ts
+++ b/src/model/OnmsAlarm.ts
@@ -87,6 +87,12 @@ export class OnmsAlarm implements IHasUrlValue {
   /** relatedAlarms - A list of alarms related to this alarm/situation */
   public relatedAlarms: OnmsAlarmSummary[];
 
+  /** managedObjectType - the type associated with this alarm if it is a situation */
+  public managedObjectType: string;
+
+  /** managedObjectInstance - the instance associated with this alarm if it is a situation */
+  public managedObjectInstance: string;
+
   /** sticky memo - a note associated with this specific alarm instance */
   public sticky: OnmsMemo;
 


### PR DESCRIPTION
As a prereq to adding the managed object bits to Helm, first `opennms-js` needs to add the properties to the alarm object.  This PR does that, and also while I was at it I added a few capabilities to the server metadata.

I've confirmed the new properties get pulled in in my Helm changes, which I will commit once this gets merged to develop and master.