### PR TITLE
JS-29: add support for "isAcknowledged" on alarms

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$"
   },
   "dependencies": {
+    "@types/lodash.clonedeep": "^4.5.6",
     "axios": "^0.16.1",
     "cli-table3": "^0.5.0",
     "commander": "^2.9.0",

--- a/src/api/IFilterVisitor.ts
+++ b/src/api/IFilterVisitor.ts
@@ -1,0 +1,16 @@
+
+import {Clause} from './Clause';
+import {Filter} from './Filter';
+import {NestedRestriction} from './NestedRestriction';
+import {Restriction} from './Restriction';
+
+/**
+ * A visitor for filters.
+ * @module FilterVisitor
+ */
+export interface IFilterVisitor {
+  onFilter?: (filter: Filter) => void;
+  onClause?: (clause: Clause) => void;
+  onRestriction?: (restriction: Restriction) => void;
+  onNestedRestriction?: (restriction: NestedRestriction) => void;
+}

--- a/src/model/OnmsAlarm.ts
+++ b/src/model/OnmsAlarm.ts
@@ -116,6 +116,11 @@ export class OnmsAlarm implements IHasUrlValue {
   /** link to the alarm details page on the source instance */
   public detailsPage: string;
 
+  /** whether the alarm has been acknowledged */
+  public get isAcknowledged() {
+    return this.ackTime !== undefined && this.ackTime !== null;
+  }
+
   /** whether the alarm is a situation */
   public get isSituation() {
     return this.relatedAlarms && this.relatedAlarms.length > 0;

--- a/src/rest/AxiosHTTP.ts
+++ b/src/rest/AxiosHTTP.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import {AxiosStatic, AxiosInstance, AxiosResponse, AxiosRequestConfig} from 'axios';
 import * as qs from 'qs';
-import * as clonedeep from 'lodash.clonedeep';
+import clonedeep from 'lodash.clonedeep';
 
 /** @hidden */
 // tslint:disable-next-line

--- a/src/rest/GrafanaHTTP.ts
+++ b/src/rest/GrafanaHTTP.ts
@@ -7,7 +7,7 @@ import {OnmsServer} from '../api/OnmsServer';
 import {log, catRest} from '../api/Log';
 import {Category} from 'typescript-logging';
 
-import * as clonedeep from 'lodash.clonedeep';
+import clonedeep from 'lodash.clonedeep';
 import {GrafanaError} from './GrafanaError';
 
 /** @hidden */
@@ -140,11 +140,11 @@ export class GrafanaHTTP extends AbstractHTTP {
    */
   private getConfig(options?: OnmsHTTPOptions): any {
     const allOptions = this.getOptions(options);
-    const ret = clonedeep(allOptions.toJSON());
+    const ret = clonedeep(allOptions.toJSON()) as any;
     ret.transformResponse = []; // we do this so we can post-process only on success
 
     if (allOptions.headers) {
-      ret.headers = clonedeep(allOptions.headers);
+      ret.headers = clonedeep(allOptions.headers) as any;
     } else {
       ret.headers = {};
     }

--- a/test/dao/AlarmDAO.spec.ts
+++ b/test/dao/AlarmDAO.spec.ts
@@ -44,6 +44,44 @@ describe('AlarmDAO with v1 API', () => {
       done();
     });
   });
+  it('AlarmDAO.getOptions()', (done) => {
+    (dao as any).getOptions().then((opts) => {
+      expect(opts).toMatchObject({});
+      done();
+    });
+  });
+  it('AlarmDAO.getOptions(isAcknowledged=true)', (done) => {
+    const filter = new Filter().withOrRestriction(new Restriction('isAcknowledged', Comparators.EQ, 'true'));
+    (dao as any).getOptions(filter).then((opts) => {
+      expect(opts.parameters).toBeDefined();
+      expect(opts.parameters.alarmAckTime).toEqual('notnull');
+      done();
+    });
+  });
+  it('AlarmDAO.getOptions(isAcknowledged=false)', (done) => {
+    const filter = new Filter().withOrRestriction(new Restriction('isAcknowledged', Comparators.EQ, 'false'));
+    (dao as any).getOptions(filter).then((opts) => {
+      expect(opts.parameters).toBeDefined();
+      expect(opts.parameters.alarmAckTime).toEqual('null');
+      done();
+    });
+  });
+  it('AlarmDAO.getOptions(isAcknowledged!=true)', (done) => {
+    const filter = new Filter().withOrRestriction(new Restriction('isAcknowledged', Comparators.NE, 'true'));
+    (dao as any).getOptions(filter).then((opts) => {
+      expect(opts.parameters).toBeDefined();
+      expect(opts.parameters.alarmAckTime).toEqual('null');
+      done();
+    });
+  });
+  it('AlarmDAO.getOptions(isAcknowledged!=false)', (done) => {
+    const filter = new Filter().withOrRestriction(new Restriction('isAcknowledged', Comparators.NE, 'false'));
+    (dao as any).getOptions(filter).then((opts) => {
+      expect(opts.parameters).toBeDefined();
+      expect(opts.parameters.alarmAckTime).toEqual('notnull');
+      done();
+    });
+  });
   it('AlarmDAO.get(404725)', () => {
     return dao.get(404725).then((alarm) => {
       expect(alarm.id).toEqual(404725);
@@ -56,6 +94,44 @@ describe('AlarmDAO with v1 API', () => {
     filter.withOrRestriction(new Restriction('id', Comparators.EQ, 404725));
     return dao.find(filter).then((alarms) => {
       expect(alarms.length).toEqual(1);
+    });
+  });
+  it('AlarmDAO.find(isAcknowledged=true)', () => {
+    const filter = new Filter();
+    filter.withOrRestriction(new Restriction('isAcknowledged', Comparators.EQ, 'true'));
+    return dao.find(filter).then((alarms) => {
+      expect(alarms.length).toEqual(1);
+      expect(alarms[0].ackTime).toBeDefined();
+      expect(alarms[0].ackTime.valueOf()).toEqual(1495806508530);
+      expect(alarms[0].ackUser).toEqual('ranger');
+    });
+  });
+  it('AlarmDAO.find(isAcknowledged=false)', () => {
+    const filter = new Filter();
+    filter.withOrRestriction(new Restriction('isAcknowledged', Comparators.EQ, 'false'));
+    return dao.find(filter).then((alarms) => {
+      expect(alarms.length).toEqual(1);
+      expect(alarms[0].ackTime).not.toBeDefined();
+      expect(alarms[0].ackUser).not.toBeDefined();
+    });
+  });
+  it('AlarmDAO.find(isAcknowledged!=true)', () => {
+    const filter = new Filter();
+    filter.withOrRestriction(new Restriction('isAcknowledged', Comparators.NE, 'true'));
+    return dao.find(filter).then((alarms) => {
+      expect(alarms.length).toEqual(1);
+      expect(alarms[0].ackTime).not.toBeDefined();
+      expect(alarms[0].ackUser).not.toBeDefined();
+    });
+  });
+  it('AlarmDAO.find(isAcknowledged!=false)', () => {
+    const filter = new Filter();
+    filter.withOrRestriction(new Restriction('isAcknowledged', Comparators.NE, 'false'));
+    return dao.find(filter).then((alarms) => {
+      expect(alarms.length).toEqual(1);
+      expect(alarms[0].ackTime).toBeDefined();
+      expect(alarms[0].ackTime.valueOf()).toEqual(1495806508530);
+      expect(alarms[0].ackUser).toEqual('ranger');
     });
   });
   it('AlarmDAO.searchProperties() should reject', () => {
@@ -162,6 +238,44 @@ describe('AlarmDAO with v2 API', () => {
       done();
     });
   });
+  it('AlarmDAO.getOptions()', (done) => {
+    (dao as any).getOptions().then((opts) => {
+      expect(opts).toMatchObject({});
+      done();
+    });
+  });
+  it('AlarmDAO.getOptions(isAcknowledged=true)', (done) => {
+    const filter = new Filter().withOrRestriction(new Restriction('isAcknowledged', Comparators.EQ, 'true'));
+    (dao as any).getOptions(filter).then((opts) => {
+      expect(opts.parameters).toBeDefined();
+      expect(opts.parameters._s).toEqual('alarmAckTime!=\u0000');
+      done();
+    });
+  });
+  it('AlarmDAO.getOptions(isAcknowledged=false)', (done) => {
+    const filter = new Filter().withOrRestriction(new Restriction('isAcknowledged', Comparators.EQ, 'false'));
+    (dao as any).getOptions(filter).then((opts) => {
+      expect(opts.parameters).toBeDefined();
+      expect(opts.parameters._s).toEqual('alarmAckTime==\u0000');
+      done();
+    });
+  });
+  it('AlarmDAO.getOptions(isAcknowledged!=true)', (done) => {
+    const filter = new Filter().withOrRestriction(new Restriction('isAcknowledged', Comparators.NE, 'true'));
+    (dao as any).getOptions(filter).then((opts) => {
+      expect(opts.parameters).toBeDefined();
+      expect(opts.parameters._s).toEqual('alarmAckTime==\u0000');
+      done();
+    });
+  });
+  it('AlarmDAO.getOptions(isAcknowledged!=false)', (done) => {
+    const filter = new Filter().withOrRestriction(new Restriction('isAcknowledged', Comparators.NE, 'false'));
+    (dao as any).getOptions(filter).then((opts) => {
+      expect(opts.parameters).toBeDefined();
+      expect(opts.parameters._s).toEqual('alarmAckTime!=\u0000');
+      done();
+    });
+  });
   it('AlarmDAO.get(6806)', () => {
     return dao.get(6806).then((alarm) => {
       expect(alarm.id).toEqual(6806);
@@ -181,6 +295,43 @@ describe('AlarmDAO with v2 API', () => {
       expect(alarms[0].id).toEqual(6806);
     });
   });
+  it('AlarmDAO.find(isAcknowledged=true)', () => {
+    const filter = new Filter().withOrRestriction(new Restriction('isAcknowledged', Comparators.EQ, 'true'));
+    return dao.find(filter).then((alarms) => {
+      console.log('alarms=', JSON.stringify(alarms, undefined, 2));
+      expect(alarms.length).toEqual(1);
+      expect(alarms[0].ackTime).toBeDefined();
+      expect(alarms[0].ackTime.valueOf()).toEqual(1495806508530);
+      expect(alarms[0].ackUser).toEqual('ranger');
+    });
+  });
+  /*
+  it('AlarmDAO.find(isAcknowledged=false)', () => {
+    const filter = new Filter().withOrRestriction(new Restriction('isAcknowledged', Comparators.EQ, 'false'));
+    return dao.find(filter).then((alarms) => {
+      expect(alarms.length).toEqual(1);
+      expect(alarms[0].ackTime).not.toBeDefined();
+      expect(alarms[0].ackUser).not.toBeDefined();
+    });
+  });
+  it('AlarmDAO.find(isAcknowledged!=true)', () => {
+    const filter = new Filter().withOrRestriction(new Restriction('isAcknowledged', Comparators.NE, 'true'));
+    return dao.find(filter).then((alarms) => {
+      expect(alarms.length).toEqual(1);
+      expect(alarms[0].ackTime).not.toBeDefined();
+      expect(alarms[0].ackUser).not.toBeDefined();
+    });
+  });
+  it('AlarmDAO.find(isAcknowledged!=false)', () => {
+    const filter = new Filter().withOrRestriction(new Restriction('isAcknowledged', Comparators.NE, 'false'));
+    return dao.find(filter).then((alarms) => {
+      expect(alarms.length).toEqual(1);
+      expect(alarms[0].ackTime).toBeDefined();
+      expect(alarms[0].ackTime.valueOf()).toEqual(1495806508530);
+      expect(alarms[0].ackUser).toEqual('ranger');
+    });
+  });
+  */
   it('AlarmDAO.find(uei=should-not-exist)', () => {
     const filter = new Filter();
     filter.withOrRestriction(new Restriction('alarm.uei', Comparators.EQ, 'should-not-exist'));

--- a/test/rest/MockHTTP19.ts
+++ b/test/rest/MockHTTP19.ts
@@ -5,6 +5,8 @@ declare const Promise, require;
 // tslint:disable-next-line
 const URI = require('urijs');
 
+import clonedeep from 'lodash.clonedeep';
+
 import {AbstractHTTP} from '../../src/rest/AbstractHTTP';
 
 import {OnmsHTTPOptions} from '../../src/api/OnmsHTTPOptions';
@@ -27,6 +29,23 @@ export class MockHTTP19 extends AbstractHTTP {
       }
       case 'rest/alarms/404725': {
         const result = OnmsResult.ok(require('./19.1.0/get/rest/alarms/404725.json'));
+        result.type = 'application/json';
+        return Promise.resolve(result);
+      }
+      case 'rest/alarms?limit=1000&alarmAckTime=notnull': {
+        const ret = clonedeep(require('./19.1.0/get/rest/alarms/id.eq.404725.json'));
+        ret.alarm[0].ackTime = 1495806508530;
+        ret.alarm[0].ackUser = 'ranger';
+        const result = OnmsResult.ok(ret);
+        result.type = 'application/json';
+        return Promise.resolve(result);
+      }
+      case 'rest/alarms?limit=1000&alarmAckTime=null': {
+        const ret = clonedeep(require('./19.1.0/get/rest/alarms/id.eq.404725.json'));
+        delete ret.alarm[0].ackId;
+        delete ret.alarm[0].ackTime;
+        delete ret.alarm[0].ackUser;
+        const result = OnmsResult.ok(ret);
         result.type = 'application/json';
         return Promise.resolve(result);
       }
@@ -67,7 +86,7 @@ export class MockHTTP19 extends AbstractHTTP {
       }
     }
 
-    throw new Error('Not yet implemented: GET ' + urlObj.toString());
+    throw new Error('19: Not yet implemented: GET ' + urlObj.toString());
   }
 
   public put(url: string, options?: OnmsHTTPOptions) {
@@ -119,7 +138,7 @@ export class MockHTTP19 extends AbstractHTTP {
       }
     }
 
-    throw new Error('Not yet implemented: PUT ' + urlObj.toString());
+    throw new Error('19: Not yet implemented: PUT ' + urlObj.toString());
   }
 
   public post(url: string, options?: OnmsHTTPOptions) {
@@ -138,11 +157,11 @@ export class MockHTTP19 extends AbstractHTTP {
       */
     }
 
-    throw new Error('Not yet implemented: POST ' + urlObj.toString());
+    throw new Error('19: Not yet implemented: POST ' + urlObj.toString());
   }
 
   public httpDelete(url: string, options?: OnmsHTTPOptions): Promise<OnmsResult<any>> {
     const urlObj = new URI(url);
-    throw new Error('Not yet implemented: DELETE ' + urlObj.toString());
+    throw new Error('19: Not yet implemented: DELETE ' + urlObj.toString());
   }
 }

--- a/test/rest/MockHTTP21.ts
+++ b/test/rest/MockHTTP21.ts
@@ -5,6 +5,8 @@ declare const Promise, require;
 // tslint:disable-next-line
 const URI = require('urijs');
 
+import clonedeep from 'lodash.clonedeep';
+
 import {AbstractHTTP} from '../../src/rest/AbstractHTTP';
 
 import {OnmsHTTPOptions} from '../../src/api/OnmsHTTPOptions';
@@ -32,6 +34,23 @@ export class MockHTTP21 extends AbstractHTTP {
       }
       case 'api/v2/alarms/82416': {
         const result = OnmsResult.ok(require('./21.0.0/get/api/v2/alarms/82416.json'));
+        result.type = 'application/json';
+        return Promise.resolve(result);
+      }
+      case 'api/v2/alarms?limit=1000&_s=alarmAckTime%21%3D%00': {
+        const ret = clonedeep(require('./21.0.0/get/api/v2/alarms/id.eq.6806.json'));
+        ret.alarm[0].ackTime = 1495806508530;
+        ret.alarm[0].ackUser = 'ranger';
+        const result = OnmsResult.ok(ret);
+        result.type = 'application/json';
+        return Promise.resolve(result);
+      }
+      case 'api/v2/alarms?limit=1000&_s=alarmAckTime%3D%3D%00': {
+        const ret = clonedeep(require('./21.0.0/get/api/v2/alarms/id.eq.6806.json'));
+        delete ret.alarm[0].ackId;
+        delete ret.alarm[0].ackTime;
+        delete ret.alarm[0].ackUser;
+        const result = OnmsResult.ok(ret);
         result.type = 'application/json';
         return Promise.resolve(result);
       }
@@ -80,7 +99,7 @@ export class MockHTTP21 extends AbstractHTTP {
       }
     }
 
-    throw new Error('Not yet implemented: GET ' + urlObj.toString());
+    throw new Error('21: Not yet implemented: GET ' + urlObj.toString());
   }
 
   public put(url: string, options?: OnmsHTTPOptions) {
@@ -144,7 +163,7 @@ export class MockHTTP21 extends AbstractHTTP {
       }
     }
 
-    throw new Error('Not yet implemented: PUT ' + urlObj.toString());
+    throw new Error('21: Not yet implemented: PUT ' + urlObj.toString());
   }
 
   public post(url: string, options?: OnmsHTTPOptions) {
@@ -174,7 +193,7 @@ export class MockHTTP21 extends AbstractHTTP {
       }
     }
 
-    throw new Error('Not yet implemented: POST ' + urlObj.toString());
+    throw new Error('21: Not yet implemented: POST ' + urlObj.toString());
   }
 
   public httpDelete(url: string, options?: OnmsHTTPOptions): Promise<OnmsResult<any>> {
@@ -198,6 +217,6 @@ export class MockHTTP21 extends AbstractHTTP {
       }
     }
 
-    throw new Error('Not yet implemented: DELETE ' + urlObj.toString());
+    throw new Error('21: Not yet implemented: DELETE ' + urlObj.toString());
   }
 }

--- a/test/rest/MockHTTP22.ts
+++ b/test/rest/MockHTTP22.ts
@@ -54,21 +54,21 @@ export class MockHTTP22 extends AbstractHTTP {
       }
     }
 
-    throw new Error('Not yet implemented: GET ' + urlObj.toString());
+    throw new Error('22: Not yet implemented: GET ' + urlObj.toString());
   }
 
   public put(url: string, options?: OnmsHTTPOptions): Promise<OnmsResult<any>> {
     const urlObj = new URI(url);
-    throw new Error('Not yet implemented: PUT ' + urlObj.toString());
+    throw new Error('22: Not yet implemented: PUT ' + urlObj.toString());
   }
 
   public post(url: string, options?: OnmsHTTPOptions): Promise<OnmsResult<any>> {
     const urlObj = new URI(url);
-    throw new Error('Not yet implemented: POST ' + urlObj.toString());
+    throw new Error('22: Not yet implemented: POST ' + urlObj.toString());
   }
 
   public httpDelete(url: string, options?: OnmsHTTPOptions): Promise<OnmsResult<any>> {
     const urlObj = new URI(url);
-    throw new Error('Not yet implemented: DELETE ' + urlObj.toString());
+    throw new Error('22: Not yet implemented: DELETE ' + urlObj.toString());
   }
 }

--- a/test/rest/MockHTTP23.ts
+++ b/test/rest/MockHTTP23.ts
@@ -44,21 +44,21 @@ export class MockHTTP23 extends AbstractHTTP {
       }
     }
 
-    throw new Error('Not yet implemented: GET ' + urlObj.toString());
+    throw new Error('23: Not yet implemented: GET ' + urlObj.toString());
   }
 
   public put(url: string, options?: OnmsHTTPOptions): Promise<OnmsResult<any>> {
     const urlObj = new URI(url);
-    throw new Error('Not yet implemented: PUT ' + urlObj.toString());
+    throw new Error('23: Not yet implemented: PUT ' + urlObj.toString());
   }
 
   public post(url: string, options?: OnmsHTTPOptions): Promise<OnmsResult<any>> {
     const urlObj = new URI(url);
-    throw new Error('Not yet implemented: POST ' + urlObj.toString());
+    throw new Error('23: Not yet implemented: POST ' + urlObj.toString());
   }
 
   public httpDelete(url: string, options?: OnmsHTTPOptions): Promise<OnmsResult<any>> {
     const urlObj = new URI(url);
-    throw new Error('Not yet implemented: DELETE ' + urlObj.toString());
+    throw new Error('23: Not yet implemented: DELETE ' + urlObj.toString());
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,6 +49,18 @@
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.3.0.tgz#6316ac20a1a13c5d521a2dc661befc7184f73f5b"
 
+"@types/lodash.clonedeep@^4.5.6":
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz#3b6c40a0affe0799a2ce823b440a6cf33571d32b"
+  integrity sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.123"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.123.tgz#39be5d211478c8dd3bdae98ee75bb7efe4abfe4d"
+  integrity sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==
+
 "@types/lodash@4.14.99":
   version "4.14.99"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.99.tgz#e6e10c0a4cc16c7409b3181f1e66880d2fb7d4dc"


### PR DESCRIPTION
This PR adds support for querying `isAcknowledged` in the `AlarmDAO` in a backwards-compatible way, as well as providing a convenience decorator on top of the `OnmsAlarm` object.

This is necessary for supporting enhancements to the Helm console.