### PR TITLE
JS-39: fix auth initialization broken during refactor

### DIFF
--- a/src/api/OnmsHTTPOptions.ts
+++ b/src/api/OnmsHTTPOptions.ts
@@ -24,10 +24,13 @@ export class OnmsHTTPOptions {
     this[TIMEOUT_PROP] = t;
   }
 
-  /** The authentication config that should be used when no auth is associated with the [[OnmsServer]]. */
+  /** The authentication config that should be used. */
   public get auth(): OnmsAuthConfig {
     if (this[AUTH_PROP]) {
       return this[AUTH_PROP];
+    }
+    if (this.server && this.server.auth) {
+      return this.server.auth;
     }
     return {} as OnmsAuthConfig;
   }

--- a/src/rest/AxiosHTTP.ts
+++ b/src/rest/AxiosHTTP.ts
@@ -175,14 +175,6 @@ export class AxiosHTTP extends AbstractHTTP {
     });
   }
 
-  /** @inheritdoc */
-  protected onBasicAuth(username: string, password: string, newHash: string, oldHash?: string) {
-    this.axiosImpl.defaults.auth = {
-      password,
-      username,
-    };
-  }
-
   /**
    * Clear the current [[AxiosInstance]] so it is recreated on next request with the
    * new server configuration.
@@ -208,6 +200,7 @@ export class AxiosHTTP extends AbstractHTTP {
         password: allOptions.auth.password,
         username: allOptions.auth.username,
       };
+      this.axiosImpl.defaults.auth = cloneDeep(ret.auth);
     }
 
     if (allOptions.timeout) {
@@ -261,6 +254,7 @@ export class AxiosHTTP extends AbstractHTTP {
       if (!server) {
         throw new OnmsError('You must set a server before attempting to make queries using Axios!');
       }
+
       const allOptions = this.getOptions(options);
 
       const axiosOpts = {
@@ -277,6 +271,7 @@ export class AxiosHTTP extends AbstractHTTP {
 
       this.axiosObj = this.axiosImpl.create(axiosOpts);
     }
+
     return this.axiosObj;
   }
 


### PR DESCRIPTION
This fixes the auth issues I ran into while testing Helm fixes. Turns out my refactor worked with `AxiosHTTP`, but broke `GrafanaHTTP` for esoteric reasons.  I put it back to simplifying things a bit.