### PR TITLE
JS-44: options mishandled arrays passed to .addParameter

### DIFF
--- a/src/api/OnmsHTTPOptions.ts
+++ b/src/api/OnmsHTTPOptions.ts
@@ -207,7 +207,11 @@ export class OnmsHTTPOptionsBuilder {
    * @param value the value of the parameter to add (or `undefined`)
    */
   public addParameter(parameter: string, value?: string | string[] | number | boolean) {
-    const v = (value && !isString(value)) ? String(value) : value;
+    // if it's already an array, coerce the contents to a string
+    // otherwise, coerce it as a scalar string
+    const v = Array.isArray(value) ?
+      value.map((vv) => String(vv)) :
+      (value && !isString(value)) ? String(value) : value;
 
     // Since parameters can be repeated an arbitrary number of times we will store them in an array in the map
     // as soon as the occurrence of a given key is > 1

--- a/test/api/OnmsHTTPOptions.spec.ts
+++ b/test/api/OnmsHTTPOptions.spec.ts
@@ -1,0 +1,47 @@
+declare const describe, beforeEach, it, expect;
+
+import {OnmsHTTPOptions, OnmsHTTPOptionsBuilder} from '../../src/api/OnmsHTTPOptions';
+
+let options: OnmsHTTPOptionsBuilder;
+
+describe('OnmsHTTPOptionsBuilder', () => {
+  beforeEach(() => {
+    options = OnmsHTTPOptions.newBuilder();
+  });
+
+  describe('Parameters', () => {
+    describe('Parameters.addParameter', () => {
+      it('it should store a simple string parameter as a string', () => {
+        options.addParameter('foo', 'bar');
+        expect(options.build().parameters).toMatchObject({
+          foo: 'bar'
+        });
+      });
+      it('it should store a simple number parameter as a string', () => {
+        options.addParameter('foo', 3);
+        expect(options.build().parameters).toMatchObject({
+          foo: '3'
+        });
+      });
+      it('it should store a simple boolean parameter as a string', () => {
+        options.addParameter('foo', true);
+        expect(options.build().parameters).toMatchObject({
+          foo: 'true'
+        });
+      });
+      it('it should store an array as an array', () => {
+        options.addParameter('foo', ['bar', 'baz']);
+        expect(options.build().parameters).toMatchObject({
+          foo: ['bar', 'baz']
+        });
+      });
+      it('it should store multiple parameters as an array', () => {
+        options.addParameter('foo', 'bar');
+        options.addParameter('foo', 'baz');
+        expect(options.build().parameters).toMatchObject({
+          foo: ['bar', 'baz']
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Turns out the problem was not Grafana or Angular's defaults, but a coercion I was doing specifically if an array was passed into `.addParameter`.  This PR fixes it and is confirmed to work with multi-value parameters in my personal Helm branch.

# Pull Request Check Sheet

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new feature, is there documentation?
* [x] If this is a new feature or substantial change, are there tests that cover it?

# Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/JS-44
* Continuous Integration: [Bamboo](https://bamboo.opennms.org/), [CircleCI](https://circleci.com/gh/OpenNMS/opennms-js)
