### PR TITLE
JS-50: Add Xref validation for Antora docs in CI/CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,24 @@ jobs:
       - store_artifacts:
           path: build/api.zip
           destination: api-docs.zip
+  build-docs:
+    docker:
+      - image: antora/antora:2.3.4
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apk --no-cache add git openssh-client
+            npm i -g gitlab:antora/xref-validator
+      - checkout
+      - run:
+          name: Validate Xrefs in docs
+          command: |
+            NODE_PATH="$(npm -g root)" antora --generator @antora/xref-validator local-site.yml
+      - run:
+          name: Build docs with Antora
+          command: |
+             NODE_PATH="$(npm -g root)" antora --stacktrace generate local-site.yml
       - store_artifacts:
           path: build/site.zip
           destination: antora-docs.zip
@@ -106,6 +124,7 @@ workflows:
   build-and-merge:
     jobs:
       - build
+      - build-docs
       - merge:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,13 +45,8 @@ jobs:
           destination: api-docs.zip
   build-docs:
     docker:
-      - image: antora/antora:2.3.4
+      - image: opennms/antora:2.3.4-b6293
     steps:
-      - run:
-          name: Install dependencies
-          command: |
-            apk --no-cache add git openssh-client
-            npm i -g gitlab:antora/xref-validator
       - checkout
       - run:
           name: Validate Xrefs in docs

--- a/local-site.yml
+++ b/local-site.yml
@@ -9,7 +9,7 @@ content:
     start_path: docs-src
 ui:
   bundle:
-    url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v1.3.0/ui-bundle.zip
+    url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v1.3.1/ui-bundle.zip
 asciidoc:
   attributes:
     stem: latexmath


### PR DESCRIPTION
# Pull Request Check Sheet

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: the subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue that points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new feature, is there documentation?
* [x] If this is a new feature or substantial change, are there tests that cover it?

# Pull Request Process

I have added a local Antora build run that produces a static HTML site.zip as an artifact just with the content from the specific branch. It should give a developer and reviewer quicker feedback for validation. Added also an Xref validation step which blames when cross-references can't be resolved correctly.

# Reviewer Hint

The API docs and Antora docs were part of an npm build step, this part needs to be reviewed particularly. I've separated the Antora doc build and the xref validation into a separate job.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/JS-50
