### PR TITLE
HELM-188: implement ipinterfaces ReST endpoint

### DIFF
--- a/docs-src/antora.yml
+++ b/docs-src/antora.yml
@@ -1,5 +1,5 @@
 name: opennms-js
-version: '2.1.2-SNAPSHOT'
+version: '2.2.0-SNAPSHOT'
 title: OpenNMS.js
 nav:
   - modules/ROOT/nav.adoc

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opennms",
-  "version": "2.1.2-SNAPSHOT",
+  "version": "2.2.0-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opennms",
-  "version": "2.1.2-SNAPSHOT",
+  "version": "2.2.0-SNAPSHOT",
   "description": "Client API for the OpenNMS network monitoring platform",
   "main": "dist/opennms.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "dist": "npm run lint && npm run test && npm run build && npm run docs",
     "api": "typedoc --out dist/docs/ src",
     "docs": "npm run api && antora --stacktrace generate local-site.yml",
-    "watch": "webpack --progress --colors --watch",
+    "watch": "webpack --progress --watch",
     "test": "jest",
     "watch-test": "jest --watch",
     "dist-test": "npm run dist",

--- a/src/API.ts
+++ b/src/API.ts
@@ -20,6 +20,7 @@ import {TicketerConfig} from './api/TicketerConfig';
 import {AlarmDAO} from './dao/AlarmDAO';
 import {EventDAO} from './dao/EventDAO';
 import {FlowDAO} from './dao/FlowDAO';
+import {IpInterfaceDAO} from './dao/IpInterfaceDAO';
 import {NodeDAO} from './dao/NodeDAO';
 import {SituationFeedbackDAO} from './dao/SituationFeedbackDAO';
 import {V1FilterProcessor} from './dao/V1FilterProcessor';
@@ -96,6 +97,7 @@ const DAO = Object.freeze({
   AlarmDAO,
   EventDAO,
   FlowDAO,
+  IpInterfaceDAO,
   NodeDAO,
   SituationFeedbackDAO,
   V1FilterProcessor,

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -15,6 +15,7 @@ import {AlarmDAO} from './dao/AlarmDAO';
 import {EventDAO} from './dao/EventDAO';
 import {FlowDAO} from './dao/FlowDAO';
 import {NodeDAO} from './dao/NodeDAO';
+import {IpInterfaceDAO} from './dao/IpInterfaceDAO';
 import {SituationFeedbackDAO} from './dao/SituationFeedbackDAO';
 
 import {AxiosHTTP} from './rest/AxiosHTTP';
@@ -158,6 +159,11 @@ export class Client implements IHasHTTP {
     return this.getDao('nodes', NodeDAO) as NodeDAO;
   }
 
+  /** Get an IP interface DAO for querying interfaces. */
+  public ipInterfaces() {
+    return this.getDao('ipInterfaces', IpInterfaceDAO) as IpInterfaceDAO;
+  }
+
   /** Get a flow DAO for querying flows. */
   public flows() {
     return this.getDao('flows', FlowDAO) as FlowDAO;
@@ -176,7 +182,7 @@ export class Client implements IHasHTTP {
    */
   private getDao(
     key: string,
-    daoClass: typeof AlarmDAO | typeof EventDAO | typeof NodeDAO | typeof FlowDAO | typeof SituationFeedbackDAO,
+    daoClass: typeof AlarmDAO | typeof EventDAO | typeof NodeDAO | typeof IpInterfaceDAO | typeof FlowDAO | typeof SituationFeedbackDAO,
   ) {
     const existing = this.daos.get(key);
     if (existing) {

--- a/src/api/OnmsVersion.ts
+++ b/src/api/OnmsVersion.ts
@@ -36,35 +36,35 @@ export class OnmsVersion {
   /**
    * Returns true if this version is less than the passed version.
    */
-  public lt(compare = '0.0.0') {
+  public lt(compare = '0.0.0'): boolean {
     return VersionCompare.lt(this.version, compare);
   }
 
   /**
    * Returns true if this version is less than or equal to the passed version.
    */
-  public le(compare = '0.0.0') {
+  public le(compare = '0.0.0'): boolean {
     return VersionCompare.lte(this.version, compare);
   }
 
   /**
    * Returns true if this version is equal to the passed version.
    */
-  public eq(compare = '0.0.0') {
+  public eq(compare = '0.0.0'): boolean {
     return VersionCompare.matches(this.version, compare);
   }
 
   /**
    * Returns true if this version is greater than or equal to the passed version.
    */
-  public ge(compare = '0.0.0') {
+  public ge(compare = '0.0.0'): boolean {
     return VersionCompare.gte(this.version, compare);
   }
 
   /**
    * Returns true if this version is greater than the passed version.
    */
-  public gt(compare = '0.0.0') {
+  public gt(compare = '0.0.0'): boolean {
     return VersionCompare.gt(this.version, compare);
   }
 

--- a/src/api/ServerMetadata.ts
+++ b/src/api/ServerMetadata.ts
@@ -119,37 +119,52 @@ export class ServerMetadata {
     }
   }
 
+  /** Does this version support the api/v2/ipinterfaces ReST endpoint? */
+  public ipInterfaceRest() {
+    if (this.type === ServerTypes.MERIDIAN) {
+      return this.version.ge('2022.0.0');
+    } else {
+      return this.version.ge('29.0.0');
+    }
+  }
+
   /** Returns a convenient data structure with all capabilities listed. */
   public capabilities(): {[key: string]: any} {
     return {
-      ackAlarms: this.ackAlarms(),
+      version: this.version.toString(),
       apiVersion: this.apiVersion(),
+      type: (this.type === ServerTypes.MERIDIAN ? 'Meridian' : 'Horizon'),
+
+      ackAlarms: this.ackAlarms(),
       enhancedFlows: this.enhancedFlows(),
       flows: this.flows(),
-      tos: this.tos(),
       graphs: this.graphs(),
+      ipInterfaceRest: this.ipInterfaceRest(),
       outageSummaries: this.outageSummaries(),
       setNodeLocation: this.setNodeLocation(),
       situations: this.situations(),
       ticketer: this.ticketer(),
-      type: (this.type === ServerTypes.MERIDIAN ? 'Meridian' : 'Horizon'),
+      tos: this.tos(),
     };
   }
 
   /** A human-readable representation of the metadata. */
   public toString() {
-    return 'ServerMetadata[version=' + this.version.toString()
+    return 'ServerMetadata['
+      + 'version=' + this.version.toString()
       + ',apiVersion=' + this.apiVersion()
       + ',type=' + this.type.toString()
+
       + ',ackAlarms=' + this.ackAlarms()
       + ',enhancedFlows=' + this.enhancedFlows()
       + ',flows=' + this.flows()
-      + ',tos=' + this.tos()
       + ',graphs=' + this.graphs()
+      + ',ipInterfaceRest=' + this.ipInterfaceRest()
       + ',outageSummaries=' + this.outageSummaries()
       + ',setNodeLocation=' + this.setNodeLocation()
       + ',situations=' + this.situations()
       + ',ticketer=' + this.ticketer()
+      + ',tos=' + this.tos()
       + ']';
   }
 

--- a/src/dao/AbstractDAO.ts
+++ b/src/dao/AbstractDAO.ts
@@ -50,13 +50,13 @@ export abstract class AbstractDAO<K, T> extends BaseDAO implements IValueProvide
    * Retrieve a model object.
    * @param id - the ID of the object
    */
-  public abstract async get(id: K): Promise<T>;
+  public abstract get(id: K): Promise<T>;
 
   /**
    * Find all model objects given an optional filter.
    * @param filter - the filter to use when retrieving a list of model objects
    */
-  public abstract async find(filter?: Filter): Promise<T[]>;
+  public abstract find(filter?: Filter): Promise<T[]>;
 
   /**
    * Get the list properties that can be used in queries.

--- a/src/dao/BaseDAO.ts
+++ b/src/dao/BaseDAO.ts
@@ -12,6 +12,7 @@ const moment = require('moment');
 /** @hidden */
 // tslint:disable-next-line
 import {Moment} from 'moment';
+import { Util } from '../internal/Util';
 
 /**
  * A base DAO useful for subclassing to create real DAOs.  This differs from
@@ -155,19 +156,17 @@ export abstract class BaseDAO {
 
   /**
    * Convert the given value to a date, or undefined if it cannot be converted.
+   * @deprecated use {@link Util.toDate} instead.
    */
   protected toDate(from: any): Moment|undefined {
-    if (from === undefined || from === null || from === '') {
-      return undefined;
-    }
-    return moment(from);
+    return Util.toDate(from);
   }
 
   /**
    * Convert the given value to a number, or undefined if it cannot be converted.
+   * @deprecated use {@link Util.toNumber} instead.
    */
   protected toNumber(from: any): number|undefined {
-    const ret = parseInt(from, 10);
-    return isNaN(ret) ? undefined : ret;
+    return Util.toNumber(from);
   }
 }

--- a/src/dao/IpInterfaceDAO.ts
+++ b/src/dao/IpInterfaceDAO.ts
@@ -1,0 +1,90 @@
+import {AbstractDAO} from './AbstractDAO';
+
+import {Filter} from '../api/Filter';
+import {IHasHTTP} from '../api/IHasHTTP';
+import {IOnmsHTTP} from '../api/IOnmsHTTP';
+import {OnmsError} from '../api/OnmsError';
+
+import { OnmsIpInterface } from '../model/OnmsIpInterface';
+
+/**
+ * Data access for [[OnmsIpInterface]] objects.
+ * @category DAO
+ */
+export class IpInterfaceDAO extends AbstractDAO<number, OnmsIpInterface> {
+  constructor(impl: IHasHTTP | IOnmsHTTP) {
+    super(impl);
+  }
+
+  /**
+   * Get an IP interface, given the interface's ID.
+   *
+   * @param id - The interface's ID.
+   */
+  public async get(id: number): Promise<OnmsIpInterface> {
+    this.assertV2();
+    return this.getOptions().then((builder) => {
+        return this.http.get(this.getRoot() + '/' + id, builder.build()).then((result) => {
+            const node = OnmsIpInterface.fromData(result.data);
+
+            if (!node) {
+              throw new OnmsError(`IpInterfaceDAO.get id={id} ReST request succeeded, but did not return a valid node.`);
+            }
+
+            return node;
+        });
+    });
+  }
+
+  /** Search for IP interfaces, given an optional filter. */
+  public async find(filter?: Filter): Promise<OnmsIpInterface[]> {
+    this.assertV2();
+    return this.getOptions(filter).then((builder) => {
+        return this.http.get(this.getRoot(), builder.build()).then((result) => {
+            let data = result.data;
+
+            if (data !== null && this.getCount(data, result.code) > 0 && data.ipInterface) {
+                data = data.ipInterface;
+            } else {
+                data = [];
+            }
+
+            if (!Array.isArray(data)) {
+                if (data.id) {
+                    data = [data];
+                } else {
+                    throw new OnmsError('Expected an array of IP interfaces but got "' + (typeof data) + '" instead.');
+                }
+            }
+            return data.map((ifaceData: any) => {
+                return OnmsIpInterface.fromData(ifaceData);
+            });
+        });
+    });
+  }
+
+  /**
+   * The path to the node search properties endpoint.
+   */
+  protected searchPropertyPath(): string {
+    return this.getRoot() + '/properties';
+  }
+
+  /**
+   * The root of the IpInterfaces ReST API.
+   * @hidden
+   */
+  private getRoot() {
+    return 'api/v2/ipinterfaces';
+  }
+
+  /**
+   * Make sure v2 is supported.
+   * @hidden
+   */
+   private assertV2() {
+    if (this.getApiVersion() < 2) {
+      throw new OnmsError('The IP interface ReST API is only available on v2.');
+    }
+  }
+}

--- a/src/dao/NodeDAO.ts
+++ b/src/dao/NodeDAO.ts
@@ -5,22 +5,10 @@ import {IHasHTTP} from '../api/IHasHTTP';
 import {IOnmsHTTP} from '../api/IOnmsHTTP';
 import {OnmsError} from '../api/OnmsError';
 
-import {Util} from '../internal/Util';
-
-import {OnmsCategory} from '../model/OnmsCategory';
-import {OnmsCollectType} from '../model/OnmsCollectType';
 import {OnmsIpInterface} from '../model/OnmsIpInterface';
-import {OnmsManagedType} from '../model/OnmsManagedType';
 import {OnmsMonitoredService} from '../model/OnmsMonitoredService';
 import {OnmsNode} from '../model/OnmsNode';
-import {OnmsNodeLabelSource} from '../model/OnmsNodeLabelSource';
-import {OnmsNodeType} from '../model/OnmsNodeType';
-import {OnmsPrimaryType} from '../model/OnmsPrimaryType';
-import {OnmsServiceType} from '../model/OnmsServiceType';
-import {OnmsServiceStatusType} from '../model/OnmsServiceStatusType';
 import {OnmsSnmpInterface} from '../model/OnmsSnmpInterface';
-import {OnmsSnmpStatusType} from '../model/OnmsSnmpStatusType';
-import {PhysAddr} from '../model/PhysAddr';
 
 /**
  * Data access for [[OnmsNode]] objects.
@@ -215,52 +203,7 @@ export class NodeDAO extends AbstractDAO<number, OnmsNode> {
    * @hidden
    */
   public fromData(data: any) {
-    const node = new OnmsNode();
-
-    if (!data) {
-      return undefined;
-    }
-
-    node.id = this.toNumber(data.id);
-    node.label = data.label;
-    node.location = data.location;
-    node.foreignSource = data.foreignSource || undefined;
-    node.foreignId = data.foreignId || undefined;
-    node.sysContact = data.sysContact;
-    node.sysDescription = data.sysDescription;
-    node.sysLocation = data.sysLocation;
-    node.sysName = data.sysName;
-    node.sysObjectId = data.sysObjectId;
-
-    if (data.labelSource) {
-      node.labelSource = OnmsNodeLabelSource.forId(data.labelSource);
-    }
-    if (data.createTime) {
-      node.createTime = this.toDate(data.createTime);
-    }
-    if (data.lastCapsdPoll) {
-      node.lastCapsdPoll = this.toDate(data.lastCapsdPoll);
-    }
-    if (data.type) {
-      node.type = OnmsNodeType.forId(data.type);
-    }
-
-    node.categories = [];
-    if (data.categories) {
-      node.categories = data.categories.map((c: any) => {
-        return OnmsCategory.for(c.id, c.name);
-      });
-    }
-
-    for (const key in data.assetRecord) {
-      if (data.assetRecord.hasOwnProperty(key)
-        && data.assetRecord[key] !== null
-        && data.assetRecord[key] !== undefined) {
-        node.assets[key] = data.assetRecord[key];
-      }
-    }
-
-    return node;
+    return OnmsNode.fromData(data);
   }
 
   /**
@@ -268,20 +211,7 @@ export class NodeDAO extends AbstractDAO<number, OnmsNode> {
    * @hidden
    */
   public fromIpInterfaceData(data: any): OnmsIpInterface {
-    const iface = new OnmsIpInterface();
-
-    iface.id = this.toNumber(data.id);
-    iface.hostname = data.hostName || data.hostname;
-    iface.ipAddress = Util.toIPAddress(data.ipAddress);
-    iface.isManaged = OnmsManagedType.forId(data.isManaged);
-    iface.lastCapsdPoll = this.toDate(data.lastCapsdPoll);
-    iface.snmpPrimary = OnmsPrimaryType.forId(data.snmpPrimary);
-
-    if (data.snmpInterface && data.snmpInterface.id) {
-      iface.snmpInterfaceId = this.toNumber(data.snmpInterface.id);
-    }
-
-    return iface;
+    return OnmsIpInterface.fromData(data);
   }
 
   /**
@@ -289,27 +219,7 @@ export class NodeDAO extends AbstractDAO<number, OnmsNode> {
    * @hidden
    */
   public fromSnmpData(data: any): OnmsSnmpInterface {
-    const iface = new OnmsSnmpInterface();
-
-    iface.id = this.toNumber(data.id);
-    iface.ifIndex = this.toNumber(data.ifIndex);
-    iface.ifDescr = data.ifDescr;
-    iface.ifType = this.toNumber(data.ifType);
-    iface.ifName = data.ifName;
-    iface.ifSpeed = this.toNumber(data.ifSpeed);
-    iface.ifAdminStatus = OnmsSnmpStatusType.forId(this.toNumber(data.ifAdminStatus));
-    iface.ifOperStatus = OnmsSnmpStatusType.forId(this.toNumber(data.ifOperStatus));
-    iface.ifAlias = data.ifAlias;
-    iface.lastCapsdPoll = this.toDate(data.lastCapsdPoll);
-    iface.collect = OnmsCollectType.forId(data.collectFlag);
-    iface.poll = data.poll;
-    iface.lastSnmpPoll = this.toDate(data.lastSnmpPoll);
-
-    if (data.physAddr) {
-      iface.physAddr = new PhysAddr(data.physAddr);
-    }
-
-    return iface;
+    return OnmsSnmpInterface.fromData(data);
   }
 
   /**
@@ -317,20 +227,7 @@ export class NodeDAO extends AbstractDAO<number, OnmsNode> {
    * @hidden
    */
   public fromServiceData(data: any): OnmsMonitoredService {
-    const service = new OnmsMonitoredService();
-
-    service.id = this.toNumber(data.id);
-    service.lastFail = this.toDate(data.lastFail);
-    service.lastGood = this.toDate(data.lastGood);
-
-    if (data.serviceType) {
-      service.type = OnmsServiceType.for(data.serviceType.id, data.serviceType.name);
-    }
-    if (data.status) {
-      service.status = OnmsServiceStatusType.forId(data.status);
-    }
-
-    return service;
+    return OnmsMonitoredService.fromData(data);
   }
 
   /**

--- a/src/internal/Util.ts
+++ b/src/internal/Util.ts
@@ -104,4 +104,21 @@ export class Util {
     return k ? search[k] : undefined;
   }
 
+  /**
+   * Convert the given value to a date, or undefined if it cannot be converted.
+   */
+   public static toDate(from: any): Moment|undefined {
+    if (from === undefined || from === null || from === '') {
+      return undefined;
+    }
+    return moment(from);
+  }
+
+  /**
+   * Convert the given value to a number, or undefined if it cannot be converted.
+   */
+  public static toNumber(from: any): number|undefined {
+    const ret = parseInt(from, 10);
+    return isNaN(ret) ? undefined : ret;
+  }
 }

--- a/src/model/OnmsIpInterface.ts
+++ b/src/model/OnmsIpInterface.ts
@@ -2,16 +2,21 @@ import {Address4, Address6} from 'ip-address';
 import {Moment} from 'moment';
 
 import {IHasUrlValue} from '../api/IHasUrlValue';
+import { Util } from '../internal/Util';
 
 import {OnmsManagedType} from './OnmsManagedType';
 import {OnmsMonitoredService} from './OnmsMonitoredService';
 import {OnmsPrimaryType} from './OnmsPrimaryType';
+import {OnmsSnmpInterface} from './OnmsSnmpInterface';
 
 /**
  * Represents an OpenNMS IP interface.
  * @category Model
  */
 export class OnmsIpInterface implements IHasUrlValue {
+  /** store the interface's associated SNMP interface, used by get/set `.snmpInterface` */
+  private _snmpInterface?: OnmsSnmpInterface;
+
   /** the interface ID */
   public id?: number;
 
@@ -21,11 +26,23 @@ export class OnmsIpInterface implements IHasUrlValue {
   /** the hostname */
   public hostname?: string;
 
+  /** whether the interface is down */
+  public isDown?: boolean;
+
   /** whether the interface is managed */
   public isManaged?: OnmsManagedType;
 
   /** the last time the interface was provisioned */
   public lastCapsdPoll?: Moment;
+
+  /** the last time ingress flows were received */
+  public lastIngressFlow?: Moment;
+
+  /** the last time egress flows were received */
+  public lastEgressFlow?: Moment;
+
+  /** the number of monitored services this interface has */
+  public monitoredServiceCount?: number;
 
   /** the SNMP primary status of the interface */
   public snmpPrimary?: OnmsPrimaryType;
@@ -34,8 +51,10 @@ export class OnmsIpInterface implements IHasUrlValue {
   public snmpInterfaceId?: number;
 
   /** the SNMP interface, if it appears on the node */
-  public get snmpInterface() {
-    if (this.node) {
+  public get snmpInterface(): OnmsSnmpInterface | undefined {
+    if (this._snmpInterface) {
+      return this._snmpInterface;
+    } else if (this.node) {
       for (const iface of this.node.snmpInterfaces) {
         if (iface.id === this.snmpInterfaceId) {
           return iface;
@@ -43,6 +62,10 @@ export class OnmsIpInterface implements IHasUrlValue {
       }
     }
     return undefined;
+  }
+
+  public set snmpInterface(iface: OnmsSnmpInterface | undefined) {
+    this._snmpInterface = iface;
   }
 
   /** the node this interface is associated with */
@@ -54,5 +77,38 @@ export class OnmsIpInterface implements IHasUrlValue {
   /** @inheritdoc */
   public get urlValue() {
     return String(this.id);
+  }
+
+  /**
+   * create an IP interface object from a JSON object
+   * @hidden
+   */
+   public static fromData(data: any) {
+    const iface = new OnmsIpInterface();
+
+    iface.id = Util.toNumber(data.id);
+
+    iface.hostname = data.hostName || data.hostname;
+    iface.ipAddress = Util.toIPAddress(data.ipAddress);
+    iface.isDown = !!data.isDown;
+    iface.isManaged = OnmsManagedType.forId(data.isManaged);
+    iface.lastCapsdPoll = Util.toDate(data.lastCapsdPoll);
+    iface.lastIngressFlow = Util.toDate(data.lastIngressFlow);
+    iface.lastEgressFlow = Util.toDate(data.lastEgressFlow);
+    iface.monitoredServiceCount = Util.toNumber(data.monitoredServiceCount);
+    iface.snmpPrimary = OnmsPrimaryType.forId(data.snmpPrimary);
+
+    if (data.nodeId !== undefined) {
+      iface.node = {};
+      iface.node.id = Util.toNumber(data.nodeId);
+    }
+
+
+    if (data.snmpInterface && data.snmpInterface.id) {
+      iface.snmpInterfaceId = Util.toNumber(data.snmpInterface.id);
+      iface.snmpInterface = OnmsSnmpInterface.fromData(data.snmpInterface);
+    }
+
+    return iface;
   }
 }

--- a/src/model/OnmsMonitoredService.ts
+++ b/src/model/OnmsMonitoredService.ts
@@ -4,6 +4,7 @@ import {IHasUrlValue} from '../api/IHasUrlValue';
 
 import {OnmsServiceType} from './OnmsServiceType';
 import {OnmsServiceStatusType} from './OnmsServiceStatusType';
+import { Util } from '../internal/Util';
 
 /**
  * Represents an OpenNMS monitored service.
@@ -35,4 +36,26 @@ export class OnmsMonitoredService implements IHasUrlValue {
   public get urlValue() {
     return this.type ? this.type.name : 'null';
   }
+
+  /**
+   * create a monitored service object from a JSON object
+   * @hidden
+   */
+   public static fromData(data: any): OnmsMonitoredService {
+    const service = new OnmsMonitoredService();
+
+    service.id = Util.toNumber(data.id);
+    service.lastFail = Util.toDate(data.lastFail);
+    service.lastGood = Util.toDate(data.lastGood);
+
+    if (data.serviceType) {
+      service.type = OnmsServiceType.for(data.serviceType.id, data.serviceType.name);
+    }
+    if (data.status) {
+      service.status = OnmsServiceStatusType.forId(data.status);
+    }
+
+    return service;
+  }
+
 }

--- a/src/model/OnmsNode.ts
+++ b/src/model/OnmsNode.ts
@@ -2,6 +2,8 @@ import {Moment} from 'moment';
 
 import {IHasUrlValue} from '../api/IHasUrlValue';
 
+import { Util } from '../internal/Util';
+
 import {OnmsCategory} from './OnmsCategory';
 import {OnmsNodeLabelSource} from './OnmsNodeLabelSource';
 import {OnmsNodeType} from './OnmsNodeType';
@@ -97,5 +99,58 @@ export class OnmsNode implements IHasUrlValue {
   /** @inheritdoc */
   public get urlValue() {
     return String(this.id);
+  }
+
+  /**
+   * Create a node object from a JSON object.
+   * @hidden
+   */
+   public static fromData(data: any) {
+    const node = new OnmsNode();
+
+    if (!data) {
+      return undefined;
+    }
+
+    node.id = Util.toNumber(data.id);
+    node.label = data.label;
+    node.location = data.location;
+    node.foreignSource = data.foreignSource || undefined;
+    node.foreignId = data.foreignId || undefined;
+    node.sysContact = data.sysContact;
+    node.sysDescription = data.sysDescription;
+    node.sysLocation = data.sysLocation;
+    node.sysName = data.sysName;
+    node.sysObjectId = data.sysObjectId;
+
+    if (data.labelSource) {
+      node.labelSource = OnmsNodeLabelSource.forId(data.labelSource);
+    }
+    if (data.createTime) {
+      node.createTime = Util.toDate(data.createTime);
+    }
+    if (data.lastCapsdPoll) {
+      node.lastCapsdPoll = Util.toDate(data.lastCapsdPoll);
+    }
+    if (data.type) {
+      node.type = OnmsNodeType.forId(data.type);
+    }
+
+    node.categories = [];
+    if (data.categories) {
+      node.categories = data.categories.map((c: any) => {
+        return OnmsCategory.for(c.id, c.name);
+      });
+    }
+
+    for (const key in data.assetRecord) {
+      if (data.assetRecord.hasOwnProperty(key)
+        && data.assetRecord[key] !== null
+        && data.assetRecord[key] !== undefined) {
+        node.assets[key] = data.assetRecord[key];
+      }
+    }
+
+    return node;
   }
 }

--- a/src/model/OnmsSnmpInterface.ts
+++ b/src/model/OnmsSnmpInterface.ts
@@ -1,6 +1,7 @@
 import {Moment} from 'moment';
 
 import {IHasUrlValue} from '../api/IHasUrlValue';
+import { Util } from '../internal/Util';
 
 import {OnmsCollectType} from './OnmsCollectType';
 import {OnmsSnmpStatusType} from './OnmsSnmpStatusType';
@@ -59,5 +60,53 @@ export class OnmsSnmpInterface implements IHasUrlValue {
   /** @inheritdoc */
   public get urlValue() {
     return String(this.id);
+  }
+
+  /**
+   * create an SNMP interface object from a JSON object
+   * @hidden
+   */
+   public static fromData(data: any): OnmsSnmpInterface {
+    const iface = new OnmsSnmpInterface();
+
+    iface.id = Util.toNumber(data.id);
+    iface.ifIndex = Util.toNumber(data.ifIndex);
+    iface.ifDescr = data.ifDescr;
+    iface.ifType = Util.toNumber(data.ifType);
+    iface.ifName = data.ifName;
+    iface.ifSpeed = Util.toNumber(data.ifSpeed);
+    iface.ifAdminStatus = OnmsSnmpStatusType.forId(Util.toNumber(data.ifAdminStatus));
+    iface.ifOperStatus = OnmsSnmpStatusType.forId(Util.toNumber(data.ifOperStatus));
+    iface.ifAlias = data.ifAlias;
+    iface.lastCapsdPoll = Util.toDate(data.lastCapsdPoll);
+    iface.collect = OnmsCollectType.forId(data.collectFlag);
+    iface.poll = data.poll;
+    iface.lastSnmpPoll = Util.toDate(data.lastSnmpPoll);
+
+    if (data.physAddr) {
+      iface.physAddr = new PhysAddr(data.physAddr);
+    }
+
+    return iface;
+  }
+
+  /** convert to JSON object */
+  public toJSON() {
+    return {
+      id: this.id,
+      ifIndex: this.ifIndex,
+      ifDescr: this.ifDescr,
+      ifType: this.ifType,
+      ifName: this.ifName,
+      ifSpeed: this.ifSpeed,
+      ifAdminStatus: this.ifAdminStatus?.toJSON(),
+      ifOperStatus: this.ifOperStatus?.toJSON(),
+      ifAlias: this.ifAlias,
+      lastCapsdPoll: this.lastCapsdPoll?.valueOf(),
+      collect: this.collect?.toJSON(),
+      poll: this.poll,
+      lastSnmpPoll: this.lastSnmpPoll?.toJSON(),
+      physAddr: this.physAddr?.urlValue,
+    }
   }
 }

--- a/test/dao/IpInterfaceDAO.spec.ts
+++ b/test/dao/IpInterfaceDAO.spec.ts
@@ -1,0 +1,68 @@
+declare const describe, beforeEach, it, expect;
+
+import {Client} from '../../src/Client';
+
+import {OnmsAuthConfig} from '../../src/api/OnmsAuthConfig';
+import {OnmsServer} from '../../src/api/OnmsServer';
+
+import {Comparators} from '../../src/api/Comparator';
+import {Filter} from '../../src/api/Filter';
+import {Restriction} from '../../src/api/Restriction';
+
+import {IpInterfaceDAO} from '../../src/dao/IpInterfaceDAO';
+
+import {MockHTTP28} from '../rest/MockHTTP28';
+import {ManagedTypes} from '../../src/model/OnmsManagedType';
+
+const SERVER_NAME = 'Demo';
+const SERVER_URL = 'http://demo.opennms.org/opennms/';
+const SERVER_USER = 'demo';
+const SERVER_PASSWORD = 'demo';
+
+let opennms: Client, server, auth, mockHTTP, dao: IpInterfaceDAO;
+
+describe('IpInterfaceDAO with v2 API', () => {
+  beforeEach((done) => {
+    auth = new OnmsAuthConfig(SERVER_USER, SERVER_PASSWORD);
+    const builder = OnmsServer.newBuilder(SERVER_URL).setName(SERVER_NAME).setAuth(auth);
+    server = builder.build();
+    mockHTTP = new MockHTTP28(server);
+    opennms = new Client(mockHTTP);
+    dao = new IpInterfaceDAO(mockHTTP);
+    Client.getMetadata(server, mockHTTP).then((metadata) => {
+      server = builder.setMetadata(metadata).build();
+      mockHTTP.server = server;
+      done();
+    });
+  });
+  it('IpInterfaceDAO.getOptions()', (done) => {
+    (dao as any).getOptions().then((opts) => {
+      expect(opts.build()).toMatchObject({});
+      done();
+    });
+  });
+  it('IpInterfaceDAO.getOptions(ipAddress=192.168.211.6)', (done) => {
+    const filter = new Filter().withOrRestriction(new Restriction('ipAddress', Comparators.EQ, '192.168.211.6'));
+    (dao as any).getOptions(filter).then((o) => {
+      const opts = o.build();
+      expect(opts.parameters).toBeDefined();
+      expect(opts.parameters._s).toEqual('ipAddress==192.168.211.6');
+      done();
+    });
+  });
+  it('IpInterfaceDAO.find()', () => {
+    const filter = new Filter();
+    return dao.find().then((ifaces) => {
+      expect(ifaces.length).toEqual(2);
+      expect(ifaces[0].id).toEqual(1);
+    });
+  });
+  it('IpInterfaceDAO.find(isManaged=M)', () => {
+    const filter = new Filter();
+    filter.withOrRestriction(new Restriction('isManaged', Comparators.EQ, ManagedTypes.MANAGED));
+    return dao.find().then((ifaces) => {
+      expect(ifaces.length).toEqual(2);
+      expect(ifaces[0].id).toEqual(1);
+    });
+  });
+});

--- a/test/dao/NodeDAO.spec.ts
+++ b/test/dao/NodeDAO.spec.ts
@@ -80,7 +80,7 @@ describe('NodeDAO with v1 API', () => {
       expect(ip.hostname).toEqual('butters.internal.opennms.com');
       expect(ip.services.length).toEqual(5);
 
-      expect(ip.snmpInterface).toEqual(snmp);
+      expect(ip.snmpInterface.toJSON()).toEqual(snmp.toJSON());
     });
   });
   it('NodeDAO.find(id=43)', () => {
@@ -144,7 +144,8 @@ describe('NodeDAO with v2 API', () => {
       expect(ip.hostname).toEqual('172.20.1.110');
       expect(ip.services.length).toEqual(3);
 
-      expect(ip.snmpInterface).toBeUndefined();
+      expect(ip.snmpInterface).toBeDefined();
+      expect(ip.snmpInterface.id).toEqual(2018);
     });
   });
   /* find is currently broken in v2

--- a/test/rest/28.0.0/get/api/v2/ipinterfaces.json
+++ b/test/rest/28.0.0/get/api/v2/ipinterfaces.json
@@ -1,0 +1,59 @@
+{
+  "count": 2,
+  "offset": 0,
+  "totalCount": 2,
+  "ipInterface": [
+    {
+      "isManaged": "M",
+      "snmpPrimary": "P",
+      "ipAddress": "127.0.0.1",
+      "monitoredServiceCount": 2,
+      "ifIndex": null,
+      "lastIngressFlow": null,
+      "lastEgressFlow": null,
+      "nodeId": 1,
+      "id": "1",
+      "hostName": "localhost",
+      "lastCapsdPoll": 1628873247203,
+      "isDown": false
+    },
+    {
+      "isManaged": "M",
+      "snmpPrimary": "P",
+      "snmpInterface": {
+        "id": 7,
+        "ifType": 1,
+        "ifAlias": "",
+        "ifIndex": 65,
+        "hasFlows": false,
+        "hasIngressFlows": false,
+        "hasEgressFlows": false,
+        "lastIngressFlow": null,
+        "lastEgressFlow": null,
+        "lastCapsdPoll": 1628878514980,
+        "ifDescr": " CPU Interface for Slot: 5 Port: 1",
+        "ifName": "CPU Interface:  5/1",
+        "physAddr": "f09fc26553be",
+        "ifSpeed": 0,
+        "ifAdminStatus": 1,
+        "ifOperStatus": 1,
+        "lastSnmpPoll": null,
+        "collectionUserSpecified": false,
+        "collectFlag": "C",
+        "pollFlag": "N",
+        "collect": true,
+        "poll": false
+      },
+      "ipAddress": "192.168.211.6",
+      "monitoredServiceCount": 3,
+      "ifIndex": 65,
+      "lastIngressFlow": null,
+      "lastEgressFlow": null,
+      "nodeId": 2,
+      "id": "5",
+      "hostName": "nonlocalhost",
+      "lastCapsdPoll": 1628878514980,
+      "isDown": false
+    }
+  ]
+}

--- a/test/rest/28.0.0/get/api/v2/ipinterfaces.properties.json
+++ b/test/rest/28.0.0/get/api/v2/ipinterfaces.properties.json
@@ -1,0 +1,711 @@
+{
+  "count": 98,
+  "offset": 0,
+  "totalCount": 98,
+  "searchProperty": [
+    {
+      "id": "id",
+      "name": "ID",
+      "type": "INTEGER",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "ipAddress",
+      "name": "IP Address",
+      "type": "IP_ADDRESS",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "ipHostName",
+      "name": "Hostname",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "ipLastCapsdPoll",
+      "name": "Last Provisioning Scan",
+      "type": "TIMESTAMP",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "isManaged",
+      "name": "Management Status",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "netMask",
+      "name": "Network Mask",
+      "type": "IP_ADDRESS",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "snmpPrimary",
+      "name": "Primary SNMP Interface Status",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false,
+      "values": {
+        "P": "P",
+        "S": "S",
+        "N": "N"
+      }
+    },
+    {
+      "id": "node.createTime",
+      "name": "Node: Creation Time",
+      "type": "TIMESTAMP",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "node.foreignId",
+      "name": "Node: Foreign ID",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "node.foreignSource",
+      "name": "Node: Foreign Source",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "node.id",
+      "name": "Node: ID",
+      "type": "INTEGER",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "node.label",
+      "name": "Node: Label",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "node.labelSource",
+      "name": "Node: Label Source",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false,
+      "values": {
+        "A": "IP Address",
+        "H": "Hostname",
+        "N": "NetBIOS",
+        "S": "SNMP sysName",
+        " ": "Unknown",
+        "U": "User-Defined"
+      }
+    },
+    {
+      "id": "node.lastCapsdPoll",
+      "name": "Node: Last Provisioning Scan",
+      "type": "TIMESTAMP",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "node.netBiosDomain",
+      "name": "Node: Windows NetBIOS Domain",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "node.netBiosName",
+      "name": "Node: Windows NetBIOS Name",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "node.operatingSystem",
+      "name": "Node: Operating System",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "node.sysContact",
+      "name": "Node: SNMP sysContact",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "node.sysDescription",
+      "name": "Node: SNMP sysDescription",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "node.sysLocation",
+      "name": "Node: SNMP sysLocation",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "node.sysName",
+      "name": "Node: SNMP sysName",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "node.sysObjectId",
+      "name": "Node: SNMP sysObjectId",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "node.type",
+      "name": "Node: Type",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false,
+      "values": {
+        "A": "Active",
+        "D": "Deleted",
+        " ": "Unknown"
+      }
+    },
+    {
+      "id": "snmpInterface.id",
+      "name": "SNMP Interface: ID",
+      "type": "INTEGER",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "snmpInterface.ifAdminStatus",
+      "name": "SNMP Interface: Admin Status",
+      "type": "INTEGER",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "snmpInterface.ifIndex",
+      "name": "SNMP Interface: Interface Index",
+      "type": "INTEGER",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "snmpInterface.ifOperStatus",
+      "name": "SNMP Interface: Operational Status",
+      "type": "INTEGER",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "snmpInterface.ifSpeed",
+      "name": "SNMP Interface: Interface Speed (Bits per second)",
+      "type": "LONG",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "snmpInterface.lastCapsdPoll",
+      "name": "SNMP Interface: Last Provisioning Scan",
+      "type": "TIMESTAMP",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "snmpInterface.lastSnmpPoll",
+      "name": "SNMP Interface: Last SNMP Interface Poll",
+      "type": "TIMESTAMP",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.additionalhardware",
+      "name": "Asset: Additional Hardware",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.admin",
+      "name": "Asset: Admin",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.assetNumber",
+      "name": "Asset: Asset Number",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.autoenable",
+      "name": "Asset: Auto-enable",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.building",
+      "name": "Asset: Building",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.category",
+      "name": "Asset: Category",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.circuitId",
+      "name": "Asset: Circuit ID",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.comment",
+      "name": "Asset: Comment",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.connection",
+      "name": "Asset: Connection",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.cpu",
+      "name": "Asset: CPU",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.dateInstalled",
+      "name": "Asset: Date Installed",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.department",
+      "name": "Asset: Department",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.description",
+      "name": "Asset: Description",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.displayCategory",
+      "name": "Asset: Display Category",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.division",
+      "name": "Asset: Division",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.enable",
+      "name": "Asset: Enable",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.floor",
+      "name": "Asset: Floor",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.hdd1",
+      "name": "Asset: HDD 1",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.hdd2",
+      "name": "Asset: HDD 2",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.hdd3",
+      "name": "Asset: HDD 3",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.hdd4",
+      "name": "Asset: HDD 4",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.hdd5",
+      "name": "Asset: HDD 5",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.hdd6",
+      "name": "Asset: HDD 6",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.id",
+      "name": "Asset: ID",
+      "type": "INTEGER",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.inputpower",
+      "name": "Asset: Input Power",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.lastModifiedBy",
+      "name": "Asset: Last Modified By",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.lastModifiedDate",
+      "name": "Asset: Last Modified Date",
+      "type": "TIMESTAMP",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.lease",
+      "name": "Asset: Lease",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.leaseExpires",
+      "name": "Asset: Lease Expires",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.maintContractExpiration",
+      "name": "Asset: Maintenance Contract Expiration",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.maintcontract",
+      "name": "Asset: Maintenance Contract",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.managedObjectInstance",
+      "name": "Asset: Managed Object Instance",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.managedObjectType",
+      "name": "Asset: Managed Object Type",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.manufacturer",
+      "name": "Asset: Manufacturer",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.modelNumber",
+      "name": "Asset: Model Number",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.notifyCategory",
+      "name": "Asset: Notify Category",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.numpowersupplies",
+      "name": "Asset: Number of Power Supplies",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.operatingSystem",
+      "name": "Asset: Operating System",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.password",
+      "name": "Asset: Password",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.pollerCategory",
+      "name": "Asset: Poller Category",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.port",
+      "name": "Asset: Port",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.rack",
+      "name": "Asset: Rack",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.rackunitheight",
+      "name": "Asset: Rack Unit Height",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.ram",
+      "name": "Asset: RAM",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.region",
+      "name": "Asset: Region",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.room",
+      "name": "Asset: Room",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.serialNumber",
+      "name": "Asset: Serial Number",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.slot",
+      "name": "Asset: Slot",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.snmpcommunity",
+      "name": "Asset: SNMP Community",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.storagectrl",
+      "name": "Asset: Storage Controller",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.supportPhone",
+      "name": "Asset: Support Phone",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.thresholdCategory",
+      "name": "Asset: Threshold Category",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.username",
+      "name": "Asset: Username",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.vendor",
+      "name": "Asset: Vendor",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.vendorAssetNumber",
+      "name": "Asset: Vendor Asset Number",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.vendorFax",
+      "name": "Asset: Vendor Fax",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "assetRecord.vendorPhone",
+      "name": "Asset: Vendor Phone",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "category.description",
+      "name": "Category: Description",
+      "type": "STRING",
+      "orderBy": false,
+      "iplike": false
+    },
+    {
+      "id": "category.id",
+      "name": "Category: ID",
+      "type": "INTEGER",
+      "orderBy": false,
+      "iplike": false
+    },
+    {
+      "id": "category.name",
+      "name": "Category: Name",
+      "type": "STRING",
+      "orderBy": false,
+      "iplike": false
+    },
+    {
+      "id": "location.geolocation",
+      "name": "Location: Geographic Address",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "location.latitude",
+      "name": "Location: Latitude",
+      "type": "FLOAT",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "location.locationName",
+      "name": "Location: ID",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "location.longitude",
+      "name": "Location: Longitude",
+      "type": "FLOAT",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "location.monitoringArea",
+      "name": "Location: Monitoring Area",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "location.priority",
+      "name": "Location: UI Priority",
+      "type": "INTEGER",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "serviceType.id",
+      "name": "Service: ID",
+      "type": "INTEGER",
+      "orderBy": true,
+      "iplike": false
+    },
+    {
+      "id": "serviceType.name",
+      "name": "Service: Service Name",
+      "type": "STRING",
+      "orderBy": true,
+      "iplike": false
+    }
+  ]
+}

--- a/test/rest/MockHTTP28.ts
+++ b/test/rest/MockHTTP28.ts
@@ -8,10 +8,10 @@ export class MockHTTP28 extends AbstractMockHTTP {
     switch(url) {
       case 'http://demo.opennms.org/opennms/rest/info': {
         return this.okJson({
-          displayVersion: '29.0.0',
+          displayVersion: '28.0.0',
           packageDescription: 'OpenNMS',
           packageName: 'opennms',
-          version: '29.0.0',
+          version: '28.0.0',
         });
       }
       // Use the v28 responses
@@ -23,6 +23,16 @@ export class MockHTTP28 extends AbstractMockHTTP {
       }
       case 'rest/flows/dscp/series': {
         return this.okJsonFile('./28.0.0/get/rest/flows/dscp/series.json');
+      }
+
+      case 'api/v2/ipinterfaces': {
+        return this.okJsonFile('./28.0.0/get/api/v2/ipinterfaces.json');
+      }
+      case 'api/v2/ipinterfaces?_s=isManaged==M': {
+        return this.okJsonFile('./28.0.0/get/api/v2/ipinterfaces.json');
+      }
+      case 'api/v2/ipinterfaces/properties': {
+        return this.okJsonFile('./28.0.0/get/api/v2/ipinterfaces.properties.json');
       }
     }
   }


### PR DESCRIPTION
This PR implements the `api/v2/ipinterfaces` ReST endpoint, which should be available technically on Horizon 28, but in practice has some bugs that will be fixed in 29.  It bumps the opennms.js version to `2.2.0` since it's a feature addition.

It also includes a couple of other small build/typescript issues I ran into while working on HELM-188.

This is a prerequisite for the Helm side of these fixes.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-188
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-js)
