### PR TITLE
HELM-345: Alarm Details missing TroubleTicketState if state is 0

### DIFF
--- a/src/internal/OnmsEnum.ts
+++ b/src/internal/OnmsEnum.ts
@@ -52,7 +52,7 @@ export class OnmsEnum<T> {
 /** convenience function for implementing id-based lookup in enums */
 /** @hidden */
 export function forId(collection: any, id?: any) {
-  if (id) {
+  if (id || (!isNaN(id) && Number.parseInt(id, 10) >= 0)) {
     for (const type in collection) {
       if (collection.hasOwnProperty(type)) {
         const collectionId = collection[type].id;

--- a/test/internal/OnmsEnum.spec.ts
+++ b/test/internal/OnmsEnum.spec.ts
@@ -1,0 +1,20 @@
+declare const describe, beforeEach, it, expect, require;
+
+import {forId} from '../../src/internal/OnmsEnum';
+import {TroubleTicketStates} from '../../src/model/OnmsTroubleTicketState';
+
+describe('Get enum for', () => {
+  it('index 0', () => {
+    const state = forId(TroubleTicketStates, 0);
+    expect(state).toBe(TroubleTicketStates.OPEN);
+  });
+  it('undefined', () => {
+    const state = forId(TroubleTicketStates, undefined);
+    expect(state).toBeUndefined();
+  });
+  it('index 1', () => {
+    const state = forId(TroubleTicketStates, 1);
+    expect(state).toBe(TroubleTicketStates.CREATE_PENDING);
+  });  
+});
+


### PR DESCRIPTION
fix(bug): truthy handling for enums when enums contain 0 as  index

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-345
* Continuous Integration: [Bamboo](https://bamboo.opennms.org/), [CircleCI](https://circleci.com/gh/OpenNMS/opennms-js)
