### PR TITLE
OPG-410: Add 'down' field to MonitoredService

### DIFF
--- a/src/model/OnmsMonitoredService.ts
+++ b/src/model/OnmsMonitoredService.ts
@@ -14,6 +14,8 @@ export class OnmsMonitoredService implements IHasUrlValue {
   /** the service ID */
   public id?: number;
 
+  public down?: boolean;
+
   /** the last time the service failed */
   public lastFail?: Moment;
 
@@ -45,6 +47,7 @@ export class OnmsMonitoredService implements IHasUrlValue {
     const service = new OnmsMonitoredService();
 
     service.id = Util.toNumber(data.id);
+    service.down = data.down;
     service.lastFail = Util.toDate(data.lastFail);
     service.lastGood = Util.toDate(data.lastGood);
 
@@ -57,5 +60,4 @@ export class OnmsMonitoredService implements IHasUrlValue {
 
     return service;
   }
-
 }

--- a/src/model/OnmsMonitoredService.ts
+++ b/src/model/OnmsMonitoredService.ts
@@ -14,6 +14,7 @@ export class OnmsMonitoredService implements IHasUrlValue {
   /** the service ID */
   public id?: number;
 
+  /** true if the service is down */
   public down?: boolean;
 
   /** the last time the service failed */

--- a/test/dao/MonitoredServiceDAO.spec.ts
+++ b/test/dao/MonitoredServiceDAO.spec.ts
@@ -1,0 +1,99 @@
+declare const describe, beforeEach, it, expect;
+
+import { Client} from '../../src/Client';
+
+import { OnmsAuthConfig} from '../../src/api/OnmsAuthConfig';
+import { OnmsServer} from '../../src/api/OnmsServer';
+import { MonitoredServiceDAO } from '../../src/dao/MonitoredServiceDAO';
+import { OnmsMonitoredService } from '../../src/model/OnmsMonitoredService';
+import { MockHTTP32} from '../rest/MockHTTP32';
+
+const SERVER_NAME = 'Demo';
+const SERVER_URL = 'http://demo.opennms.org/opennms/';
+const SERVER_USER = 'demo';
+const SERVER_PASSWORD = 'demo';
+
+let opennms: Client, server, auth, mockHTTP, dao: MonitoredServiceDAO;
+
+describe('MonitoredServiceDAO with v2 API', () => {
+  beforeEach((done) => {
+    auth = new OnmsAuthConfig(SERVER_USER, SERVER_PASSWORD);
+    const builder = OnmsServer.newBuilder(SERVER_URL).setName(SERVER_NAME).setAuth(auth);
+    server = builder.build();
+    mockHTTP = new MockHTTP32(server);
+    opennms = new Client(mockHTTP);
+    dao = new MonitoredServiceDAO(mockHTTP);
+    Client.getMetadata(server, mockHTTP).then((metadata) => {
+      server = builder.setMetadata(metadata).build();
+      mockHTTP.server = server;
+      done();
+    });
+  });
+
+  it('MonitoredServiceDAO.getOptions()', (done) => {
+    (dao as any).getOptions().then((opts) => {
+      expect(opts.build()).toMatchObject({});
+      done();
+    });
+  });
+
+  it('MonitoredServiceDAO.get(4)', () => {
+    return dao.get(4).then((service: OnmsMonitoredService) => {
+      expect(service.id).toEqual(4);
+
+      // Spot check some of the known properties
+      expect(service.down).toBeTruthy();
+      expect(service.lastGood?.valueOf()).toEqual(1651862554301);
+      expect(service.lastFail?.valueOf()).toEqual(1663000042923);
+
+      expect(service.type?.id).toEqual(1);
+      expect(service.type?.name).toEqual('DeviceConfig-default');
+
+      expect(service.status?.id).toEqual('A');
+      expect(service.status?.label).toEqual('MANAGED');
+
+      expect(service.urlValue).toEqual('DeviceConfig-default');
+    });
+  });
+
+  it('MonitoredServiceDAO.find()', () => {
+    return dao.find().then((services: OnmsMonitoredService[]) => {
+      expect(services.length).toEqual(10)
+
+      // Spot check some of the known properties
+      let service = services[0]
+      expect(service.id).toEqual(4);
+      expect(service.down).toBeTruthy();
+      expect(service.lastGood?.valueOf()).toEqual(1651862554301);
+      expect(service.lastFail?.valueOf()).toEqual(1663000042923);
+      expect(service.type?.id).toEqual(1);
+      expect(service.type?.name).toEqual('DeviceConfig-default');
+      expect(service.status?.id).toEqual('A');
+      expect(service.status?.label).toEqual('MANAGED');
+      expect(service.urlValue).toEqual('DeviceConfig-default');
+ 
+      service = services[1]
+      expect(service.id).toEqual(5);
+      expect(service.down).toBeTruthy();
+      expect(service.lastGood).not.toBeDefined();
+      expect(service.lastFail?.valueOf()).toEqual(1663000042923);
+      expect(service.type?.id).toEqual(1);
+      expect(service.type?.name).toEqual('DeviceConfig-default');
+      expect(service.status?.id).toEqual('A');
+      expect(service.status?.label).toEqual('MANAGED');
+      expect(service.urlValue).toEqual('DeviceConfig-default');
+
+      service = services[5]
+      expect(service.id).toEqual(39);
+      expect(service.down).toEqual(false);
+      expect(service.lastFail?.valueOf()).toEqual();
+      expect(service.lastGood?.valueOf()).toEqual(1663000345039);
+      expect(service.lastFail).not.toBeDefined();
+      expect(service.type?.id).toEqual(3);
+      expect(service.type?.name).toEqual('ICMP');
+      expect(service.status?.id).toEqual('A');
+      expect(service.status?.label).toEqual('MANAGED');
+      expect(service.urlValue).toEqual('ICMP');
+    });
+  });
+});

--- a/test/rest/32.0.0/get/api/v2/4.json
+++ b/test/rest/32.0.0/get/api/v2/4.json
@@ -1,0 +1,16 @@
+{
+  "down": true,
+  "notify": null,
+  "status": "A",
+  "source": null,
+  "qualifier": null,
+  "lastGood": 1651862554301,
+  "lastFail": 1663000042923,
+  "statusLong": "Managed",
+  "ipInterfaceId": 1,
+  "serviceType": {
+    "id": 1,
+    "name": "DeviceConfig-default"
+  },
+  "id": 4
+}

--- a/test/rest/32.0.0/get/api/v2/ifServices.json
+++ b/test/rest/32.0.0/get/api/v2/ifServices.json
@@ -1,0 +1,167 @@
+{
+  "count": 10,
+  "totalCount": 40,
+  "offset": 0,
+  "service": [
+    {
+      "down": true,
+      "notify": null,
+      "status": "A",
+      "source": null,
+      "qualifier": null,
+      "lastGood": 1651862554301,
+      "lastFail": 1663000042923,
+      "statusLong": "Managed",
+      "ipInterfaceId": 1,
+      "serviceType": {
+        "id": 1,
+        "name": "DeviceConfig-default"
+      },
+      "id": 4
+    },
+    {
+      "down": true,
+      "notify": null,
+      "status": "A",
+      "source": null,
+      "qualifier": null,
+      "lastGood": null,
+      "lastFail": 1663000042923,
+      "statusLong": "Managed",
+      "ipInterfaceId": 2,
+      "serviceType": {
+        "id": 1,
+        "name": "DeviceConfig-default"
+      },
+      "id": 5
+    },
+    {
+      "down": true,
+      "notify": null,
+      "status": "A",
+      "source": null,
+      "qualifier": null,
+      "lastGood": null,
+      "lastFail": 1663000042922,
+      "statusLong": "Managed",
+      "ipInterfaceId": 3,
+      "serviceType": {
+        "id": 2,
+        "name": "DeviceConfig-running"
+      },
+      "id": 6
+    },
+    {
+      "down": false,
+      "notify": null,
+      "status": null,
+      "source": null,
+      "qualifier": null,
+      "lastGood": null,
+      "lastFail": null,
+      "statusLong": null,
+      "ipInterfaceId": 2,
+      "serviceType": {
+        "id": 2,
+        "name": "DeviceConfig-running"
+      },
+      "id": 7
+    },
+    {
+      "down": true,
+      "notify": null,
+      "status": "A",
+      "source": null,
+      "qualifier": null,
+      "lastGood": null,
+      "lastFail": 1663000042922,
+      "statusLong": "Managed",
+      "ipInterfaceId": 4,
+      "serviceType": {
+        "id": 1,
+        "name": "DeviceConfig-default"
+      },
+      "id": 8
+    },
+    {
+      "down": false,
+      "notify": null,
+      "status": "A",
+      "source": null,
+      "qualifier": null,
+      "lastGood": 1663000345039,
+      "lastFail": null,
+      "statusLong": "Managed",
+      "ipInterfaceId": 37,
+      "serviceType": {
+        "id": 3,
+        "name": "ICMP"
+      },
+      "id": 39
+    },
+    {
+      "down": false,
+      "notify": null,
+      "status": "A",
+      "source": null,
+      "qualifier": null,
+      "lastGood": 1663000374044,
+      "lastFail": null,
+      "statusLong": "Managed",
+      "ipInterfaceId": 37,
+      "serviceType": {
+        "id": 4,
+        "name": "OpenNMS-JVM"
+      },
+      "id": 40
+    },
+    {
+      "down": true,
+      "notify": null,
+      "status": "A",
+      "source": null,
+      "qualifier": null,
+      "lastGood": null,
+      "lastFail": 1663000042923,
+      "statusLong": "Managed",
+      "ipInterfaceId": 45,
+      "serviceType": {
+        "id": 1,
+        "name": "DeviceConfig-default"
+      },
+      "id": 46
+    },
+    {
+      "down": true,
+      "notify": null,
+      "status": "A",
+      "source": null,
+      "qualifier": null,
+      "lastGood": 1657655058204,
+      "lastFail": 1663000199402,
+      "statusLong": "Managed",
+      "ipInterfaceId": 48,
+      "serviceType": {
+        "id": 3,
+        "name": "ICMP"
+      },
+      "id": 51
+    },
+    {
+      "down": true,
+      "notify": null,
+      "status": "A",
+      "source": null,
+      "qualifier": null,
+      "lastGood": 1657655051210,
+      "lastFail": 1657655358082,
+      "statusLong": "Managed",
+      "ipInterfaceId": 48,
+      "serviceType": {
+        "id": 5,
+        "name": "SSH"
+      },
+      "id": 52
+    }
+  ]
+}

--- a/test/rest/MockHTTP30.ts
+++ b/test/rest/MockHTTP30.ts
@@ -1,7 +1,7 @@
 import {AbstractMockHTTP} from './AbstractMockHTTP';
 import {OnmsHTTPOptions} from '../../src/api/OnmsHTTPOptions';
 
-/** Mock OpenNMS 28.x HTTP implementation */
+/** Mock OpenNMS 30.x HTTP implementation */
 export class MockHTTP30 extends AbstractMockHTTP {
   /** @inheritdoc */
   public onGet(url: string, options?: OnmsHTTPOptions) {
@@ -24,7 +24,6 @@ export class MockHTTP30 extends AbstractMockHTTP {
       case 'api/v2/snmpinterfaces?limit=1000&_s=ifName%3D%3Dsome-test':{
         return this.okJsonFile('./30.0.0/get/api/v2/snmpinterfaces.filtered.json');
       }    
-
     }
   }
 }

--- a/test/rest/MockHTTP32.ts
+++ b/test/rest/MockHTTP32.ts
@@ -1,0 +1,27 @@
+import { AbstractMockHTTP } from './AbstractMockHTTP';
+import { OnmsHTTPOptions } from '../../src/api/OnmsHTTPOptions';
+
+/** Mock OpenNMS 32.x HTTP implementation */
+export class MockHTTP32 extends AbstractMockHTTP {
+  /** @inheritdoc */
+  public onGet(url: string, options?: OnmsHTTPOptions) {
+    switch(url) {
+      case 'http://demo.opennms.org/opennms/rest/info': {
+        return this.okJson({
+          displayVersion: '32.0.0',
+          packageDescription: 'OpenNMS',
+          packageName: 'opennms',
+          version: '32.0.0',
+        });
+      }
+
+      // Use the v32 responses   
+      case 'api/v2/ifservices': {
+        return this.okJsonFile('./32.0.0/get/api/v2/ifServices.json');
+      } 
+      case 'api/v2/ifservices/4': {
+        return this.okJsonFile('./32.0.0/get/api/v2/4.json');
+      } 
+    }
+  }
+}


### PR DESCRIPTION
The MonitoredServices Rest API returns a boolean `down` parameter, but this isn't surfaced by the `opennms-js` DAO, and cannot be used by the OpenNMS plugin for Grafana.

Adding it here plus adding basic unit tests for MonitoredServicesDAO. And fixing a typo in MockHTTP30 comments.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/OPG-410
* Continuous Integration: [Bamboo](https://bamboo.opennms.org/), [CircleCI](https://circleci.com/gh/OpenNMS/opennms-js)
