### PR TITLE
NMS-16161: Add fields to Monitored Services

### DIFF
--- a/src/model/OnmsMonitoredService.ts
+++ b/src/model/OnmsMonitoredService.ts
@@ -1,3 +1,4 @@
+import { IpInterfaceDAO } from './../dao/IpInterfaceDAO';
 import {Moment} from 'moment';
 
 import {IHasUrlValue} from '../api/IHasUrlValue';
@@ -35,6 +36,14 @@ export class OnmsMonitoredService implements IHasUrlValue {
   /** the current status */
   public status?: OnmsServiceStatusType;
 
+  public ipInterfaceId?: number;
+
+  public ipAddress?: string;
+
+  public nodeId?: number;
+
+  public nodeLabel?: string;
+
   /** @inheritdoc */
   public get urlValue() {
     return this.type ? this.type.name : 'null';
@@ -57,6 +66,22 @@ export class OnmsMonitoredService implements IHasUrlValue {
     }
     if (data.status) {
       service.status = OnmsServiceStatusType.forId(data.status);
+    }
+
+    if (data.ipInterfaceId) {
+      service.ipInterfaceId = data.ipInterfaceId;
+    }
+
+    if (data.ipAddress) {
+      service.ipAddress = data.ipAddress;
+    }
+
+    if (data.nodeId) {
+      service.nodeId = data.nodeId;
+    }
+
+    if (data.nodeLabel) {
+      service.nodeLabel = data.nodeLabel;
     }
 
     return service;

--- a/test/dao/MonitoredServiceDAO.spec.ts
+++ b/test/dao/MonitoredServiceDAO.spec.ts
@@ -37,7 +37,7 @@ describe('MonitoredServiceDAO with v2 API', () => {
     });
   });
 
-  it('MonitoredServiceDAO.get(4)', () => {
+  it('MonitoredServiceDAO.get(4), does not have all fields', () => {
     return dao.get(4).then((service: OnmsMonitoredService) => {
       expect(service.id).toEqual(4);
 
@@ -53,6 +53,34 @@ describe('MonitoredServiceDAO with v2 API', () => {
       expect(service.status?.label).toEqual('MANAGED');
 
       expect(service.urlValue).toEqual('DeviceConfig-default');
+
+      expect(service.ipInterfaceId).toEqual(1);
+      expect(service.ipAddress).not.toBeDefined();
+      expect(service.nodeId).not.toBeDefined();
+    });
+  });
+
+  it('MonitoredServiceDAO.get(99), has all fields', () => {
+    return dao.get(99).then((service: OnmsMonitoredService) => {
+      expect(service.id).toEqual(99);
+
+      // Spot check some of the known properties
+      expect(service.down).toBeTruthy();
+      expect(service.lastGood?.valueOf()).toEqual(1651862554301);
+      expect(service.lastFail?.valueOf()).toEqual(1663000042923);
+
+      expect(service.type?.id).toEqual(1);
+      expect(service.type?.name).toEqual('DeviceConfig-default');
+
+      expect(service.status?.id).toEqual('A');
+      expect(service.status?.label).toEqual('MANAGED');
+
+      expect(service.urlValue).toEqual('DeviceConfig-default');
+
+      expect(service.ipInterfaceId).toEqual(101);
+      expect(service.ipAddress).toEqual('192.168.1.119');
+      expect(service.nodeId).toEqual(142);
+      expect(service.nodeLabel).toEqual('node119');
     });
   });
 

--- a/test/rest/32.0.0/get/api/v2/99.json
+++ b/test/rest/32.0.0/get/api/v2/99.json
@@ -1,0 +1,19 @@
+{
+  "down": true,
+  "notify": null,
+  "status": "A",
+  "source": null,
+  "qualifier": null,
+  "lastGood": 1651862554301,
+  "lastFail": 1663000042923,
+  "statusLong": "Managed",
+  "ipInterfaceId": 101,
+  "ipAddress": "192.168.1.119",
+  "nodeId": 142,
+  "nodeLabel": "node119",
+  "serviceType": {
+    "id": 1,
+    "name": "DeviceConfig-default"
+  },
+  "id": 99
+}

--- a/test/rest/MockHTTP32.ts
+++ b/test/rest/MockHTTP32.ts
@@ -22,6 +22,9 @@ export class MockHTTP32 extends AbstractMockHTTP {
       case 'api/v2/ifservices/4': {
         return this.okJsonFile('./32.0.0/get/api/v2/4.json');
       } 
+      case 'api/v2/ifservices/99': {
+        return this.okJsonFile('./32.0.0/get/api/v2/99.json');
+      }
     }
   }
 }


### PR DESCRIPTION
Add some read-only fields to `OnmsMonitoredService`, these will be added to OpenNMS Rest API in NMS-16160. This will handle the case whether they exist or not in the Rest API. Fields were request to be in the Grafana Plugin, OPG-454.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-16161
* Continuous Integration: [Bamboo](https://bamboo.opennms.org/), [CircleCI](https://circleci.com/gh/OpenNMS/opennms-js)
